### PR TITLE
Implement interleaved and long-read input

### DIFF
--- a/cockatoo/cockatoo.py
+++ b/cockatoo/cockatoo.py
@@ -31,7 +31,7 @@ def build_reads_list(forward, reverse):
             reverse_reads[joint_name] = os.path.abspath(reverse)
     else:
         forward_reads = {os.path.basename(read): os.path.abspath(read) for read in forward}
-        reverse_reads = None
+        reverse_reads = []
 
     return forward_reads, reverse_reads
 

--- a/cockatoo/workflow/scripts/aviary_commands.py
+++ b/cockatoo/workflow/scripts/aviary_commands.py
@@ -11,11 +11,13 @@ import pandas as pd
 def produce_command(row):
     coassembly_sample_names = row["samples"]
     coassembly_samples_1 = [snakemake.params.reads_1[sample] for sample in coassembly_sample_names]
-    coassembly_samples_2= [snakemake.params.reads_2[sample] for sample in coassembly_sample_names]
+    coassembly_samples_2= [snakemake.params.reads_2[sample] for sample in coassembly_sample_names] if snakemake.params.reads_2 else []
 
     all_samples_names = row["recover_samples"]
     all_samples_1 = [snakemake.params.reads_1[sample] for sample in all_samples_names]
-    all_samples_2 = [snakemake.params.reads_2[sample] for sample in all_samples_names]
+    all_samples_2 = [snakemake.params.reads_2[sample] for sample in all_samples_names] if snakemake.params.reads_2 else []
+
+    reverse_arg = "-2" if snakemake.params.reads_2 else ""
 
     coassembly = row["coassembly"]
     output_dir = snakemake.params.dir + "/coassemble"
@@ -24,7 +26,7 @@ def produce_command(row):
 
     aviary_assemble = ("aviary assemble "
     f"-1 {' '.join(coassembly_samples_1)} "
-    f"-2 {' '.join(coassembly_samples_2)} "
+    f"{reverse_arg} {' '.join(coassembly_samples_2)} "
     f"--output {output_dir}/{coassembly}/assemble "
     f"-n {threads} "
     f"-m {memory} "
@@ -33,7 +35,7 @@ def produce_command(row):
     aviary_recover = ("aviary recover "
     f"--assembly {output_dir}/{coassembly}/assemble/assembly/final_contigs.fasta "
     f"-1 {' '.join(all_samples_1)} "
-    f"-2 {' '.join(all_samples_2)} "
+    f"{reverse_arg} {' '.join(all_samples_2)} "
     f"--output {output_dir}/{coassembly}/recover "
     f"-n {threads} "
     f"-m {memory} "


### PR DESCRIPTION
- [x] Remove reverse requirements
- [ ] Fix map_reads output
- [ ] Switch to interleaved in aviary commands

Probably best to deinterleave at first...

From #18 (when aiming for unpaired reads)
- [ ] Fix `--sra` (account for unpaired reads)
  - [ ] Add unpaired reads as possibility (make r optional)
    - [ ] Add `--single` or `--unpaired` as separate input argument
    - [ ] Account for absent r in singlem_pipe_reads (separate unpaired rule?)
    - [ ] Account for absent r in count_bp_reads (separate unpaired rule?)
    - [ ] Account for absent r in map_reads (separate unpaired rule?)
    - [ ] Account for absent r in bam_to_fastq (separate unpaired rule?)
    - [ ] Account for absent r in aviary_commands.py
    - [ ] Account for absent r in aviary_assemble
    - [ ] Account for absent r in aviary_recover
  - [ ] Produce combined f/r and u outputs from kingfisher downloads