### PR TITLE
Improve Aviary running

### DIFF
--- a/binchicken/binchicken.py
+++ b/binchicken/binchicken.py
@@ -19,6 +19,9 @@ import shutil
 
 FAST_AVIARY_MODE = "fast"
 COMPREHENSIVE_AVIARY_MODE = "comprehensive"
+DYNAMIC_ASSEMBLY_STRATEGY = "dynamic"
+METASPADES_ASSEMBLY = "metaspades"
+MEGAHIT_ASSEMBLY = "megahit"
 
 def build_reads_list(forward, reverse):
     if reverse:
@@ -470,6 +473,7 @@ def coassemble(args):
         "unmapping_max_identity": args.unmapping_max_identity,
         "unmapping_max_alignment": args.unmapping_max_alignment,
         "aviary_speed": args.aviary_speed,
+        "assembly_strategy": args.assembly_strategy,
         "run_aviary": args.run_aviary,
         "aviary_gtdbtk": args.aviary_gtdbtk_db,
         "aviary_checkm2": args.aviary_checkm2_db,
@@ -1083,10 +1087,13 @@ def main():
         argument_group.add_argument("--max-contamination", type=int, help="Include bins with at most this maximum contamination [default: 10]", default=10)
 
     def add_aviary_options(argument_group):
-        default_aviary_speed = FAST_AVIARY_MODE
-        argument_group.add_argument("--aviary-speed", help="Run Aviary recover in 'fast' or 'comprehensive' mode. Fast mode skips slow binners and refinement steps. [default: %s]" % default_aviary_speed,
-                                    default=default_aviary_speed, choices=[FAST_AVIARY_MODE, COMPREHENSIVE_AVIARY_MODE])
         argument_group.add_argument("--run-aviary", action="store_true", help="Run Aviary commands for all identified coassemblies (unless specific coassemblies are chosen with --coassemblies) [default: do not]")
+        default_aviary_speed = FAST_AVIARY_MODE
+        argument_group.add_argument("--aviary-speed", help=f"Run Aviary recover in 'fast' or 'comprehensive' mode. Fast mode skips slow binners and refinement steps. [default: {default_aviary_speed}]",
+                                    default=default_aviary_speed, choices=[FAST_AVIARY_MODE, COMPREHENSIVE_AVIARY_MODE])
+        default_assembly_strategy = DYNAMIC_ASSEMBLY_STRATEGY
+        argument_group.add_argument("--assembly-strategy", help=f"Assembly strategy to use with Aviary. [default: {default_assembly_strategy}; attempts metaspades and if fails, switches to megahit]",
+                                    default=default_assembly_strategy, choices=[DYNAMIC_ASSEMBLY_STRATEGY, METASPADES_ASSEMBLY, MEGAHIT_ASSEMBLY])
         argument_group.add_argument("--aviary-gtdbtk-db", help="Path to GTDB-Tk database directory for Aviary. [default: use path from GTDBTK_DATA_PATH env variable]")
         argument_group.add_argument("--aviary-checkm2-db", help="Path to CheckM2 database directory for Aviary. [default: use path from CHECKM2DB env variable]")
         aviary_default_cores = 64

--- a/binchicken/binchicken.py
+++ b/binchicken/binchicken.py
@@ -477,8 +477,10 @@ def coassemble(args):
         "run_aviary": args.run_aviary,
         "aviary_gtdbtk": args.aviary_gtdbtk_db,
         "aviary_checkm2": args.aviary_checkm2_db,
-        "aviary_threads": args.aviary_cores,
-        "aviary_memory": args.aviary_memory,
+        "aviary_assemble_threads": args.aviary_assemble_cores,
+        "aviary_assemble_memory": args.aviary_assemble_memory,
+        "aviary_recover_threads": args.aviary_recover_cores,
+        "aviary_recover_memory": args.aviary_recover_memory,
         "conda_prefix": args.conda_prefix,
         "snakemake_profile": args.snakemake_profile,
         "cluster_retries": args.cluster_retries,
@@ -891,7 +893,8 @@ def build(args):
     args.sample_read_size = None
     args.aviary_gtdbtk_db = "."
     args.aviary_checkm2_db = "."
-    args.aviary_cores = None
+    args.aviary_assemble_cores = None
+    args.aviary_recover_cores = None
     args.assemble_unmapped = True
     args.run_qc = True
     args.coassemblies = None
@@ -1096,10 +1099,18 @@ def main():
                                     default=default_assembly_strategy, choices=[DYNAMIC_ASSEMBLY_STRATEGY, METASPADES_ASSEMBLY, MEGAHIT_ASSEMBLY])
         argument_group.add_argument("--aviary-gtdbtk-db", help="Path to GTDB-Tk database directory for Aviary. [default: use path from GTDBTK_DATA_PATH env variable]")
         argument_group.add_argument("--aviary-checkm2-db", help="Path to CheckM2 database directory for Aviary. [default: use path from CHECKM2DB env variable]")
-        aviary_default_cores = 64
-        argument_group.add_argument("--aviary-cores", type=int, help="Maximum number of cores for Aviary to use. Half used for recovery. [default: %s]" % aviary_default_cores, default=aviary_default_cores)
-        aviary_default_memory = 500
-        argument_group.add_argument("--aviary-memory", type=int, help="Maximum amount of memory for Aviary to use (Gigabytes). Half used for recovery. [default: %s]" % aviary_default_memory, default=aviary_default_memory)
+        aviary_assemble_default_cores = 64
+        argument_group.add_argument("--aviary-assemble-cores", type=int, help=f"Maximum number of cores for Aviary to use. [default: {aviary_assemble_default_cores}]",
+                                    default=aviary_assemble_default_cores)
+        aviary_assemble_default_memory = 500
+        argument_group.add_argument("--aviary-assemble-memory", type=int, help=f"Maximum amount of memory for Aviary to use (Gigabytes). [default: {aviary_assemble_default_memory}]",
+                                    default=aviary_assemble_default_memory)
+        aviary_recover_default_cores = 32
+        argument_group.add_argument("--aviary-recover-cores", type=int, help=f"Maximum number of cores for Aviary to use. [default: {aviary_recover_default_cores}]",
+                                    default=aviary_recover_default_cores)
+        aviary_recover_default_memory = 250
+        argument_group.add_argument("--aviary-recover-memory", type=int, help=f"Maximum amount of memory for Aviary to use (Gigabytes). [default: {aviary_recover_default_memory}]",
+                                    default=aviary_recover_default_memory)
 
     def add_main_coassemble_output_arguments(argument_group):
         argument_group.add_argument("--coassemble-output", help="Output dir from coassemble subcommand")

--- a/binchicken/config/template_coassemble.yaml
+++ b/binchicken/config/template_coassemble.yaml
@@ -22,6 +22,7 @@ unmapping_min_appraised: 1
 unmapping_max_identity: 1
 unmapping_max_alignment: 1
 aviary_speed: "fast"
+assembly_strategy: "dynamic"
 run_aviary: false
 aviary_gtdbtk: ""
 aviary_checkm2: ""

--- a/binchicken/config/template_coassemble.yaml
+++ b/binchicken/config/template_coassemble.yaml
@@ -26,8 +26,10 @@ assembly_strategy: "dynamic"
 run_aviary: false
 aviary_gtdbtk: ""
 aviary_checkm2: ""
-aviary_memory: 1
-aviary_threads: 1
+aviary_assemble_memory: 1
+aviary_assemble_threads: 1
+aviary_recover_memory: 1
+aviary_recover_threads: 1
 test: false
 mock_sra: false
 aviary_dryrun: false

--- a/binchicken/workflow/coassemble.smk
+++ b/binchicken/workflow/coassemble.smk
@@ -631,8 +631,10 @@ rule aviary_commands:
         reads_1 = mapped_reads_1 if config["assemble_unmapped"] else qc_reads_1 if config["run_qc"] else config["reads_1"],
         reads_2 = mapped_reads_2 if config["assemble_unmapped"] else qc_reads_2 if config["run_qc"] else config["reads_2"],
         dir = output_dir,
-        memory = config["aviary_memory"],
-        threads = config["aviary_threads"],
+        assemble_memory = config["aviary_assemble_memory"],
+        assemble_threads = config["aviary_assemble_threads"],
+        recover_memory = config["aviary_recover_memory"],
+        recover_threads = config["aviary_recover_threads"],
         speed = config["aviary_speed"],
     localrule: True
     log:
@@ -652,7 +654,7 @@ def get_assemble_threads(wildcards, attempt):
     elif config["assembly_strategy"] == MEGAHIT_ASSEMBLY:
         current_threads = 32 * attempt
 
-    threads = min(int(config["aviary_threads"]), current_threads)
+    threads = min(int(config["aviary_assemble_threads"]), current_threads)
 
     return threads
 
@@ -665,7 +667,7 @@ def get_assemble_memory(wildcards, attempt, unit="GB"):
     elif config["assembly_strategy"] == MEGAHIT_ASSEMBLY:
         current_mem = 250 * attempt
 
-    mem = min(int(config["aviary_memory"]), current_mem)
+    mem = min(int(config["aviary_assemble_memory"]), current_mem)
     mult = 1000 if unit == "MB" else 1
 
     return mem * mult
@@ -747,10 +749,10 @@ rule aviary_recover:
         tmpdir = config["tmpdir"],
     localrule: True
     threads:
-        int(config["aviary_threads"])//2
+        int(config["aviary_recover_threads"])
     resources:
-        mem_mb = int(config["aviary_memory"])*1000//2,
-        mem_gb = int(config["aviary_memory"])//2,
+        mem_mb = int(config["aviary_recover_memory"])*1000,
+        mem_gb = int(config["aviary_recover_memory"]),
         runtime = "168h",
     log:
         logs_dir + "/aviary/{coassembly}_recover.log"

--- a/binchicken/workflow/scripts/aviary_commands.py
+++ b/binchicken/workflow/scripts/aviary_commands.py
@@ -7,7 +7,7 @@ import os
 import polars as pl
 from binchicken.binchicken import FAST_AVIARY_MODE
 
-def pipeline(coassemblies, reads_1, reads_2, output_dir, threads, memory, fast=False):
+def pipeline(coassemblies, reads_1, reads_2, output_dir, assemble_threads, assemble_memory, recover_threads, recover_memory, fast=False):
     output = (
         coassemblies
         .with_columns(
@@ -31,11 +31,11 @@ def pipeline(coassemblies, reads_1, reads_2, output_dir, threads, memory, fast=F
                 pl.lit("/coassemble/"),
                 pl.col("coassembly"),
                 pl.lit("/assemble -n "),
-                pl.lit(threads),
+                pl.lit(assemble_threads),
                 pl.lit(" -t "),
-                pl.lit(threads),
+                pl.lit(assemble_threads),
                 pl.lit(" -m "),
-                pl.lit(memory),
+                pl.lit(assemble_memory),
                 pl.lit(" --skip-qc &> "),
                 pl.lit(output_dir),
                 pl.lit("/coassemble/logs/"),
@@ -58,11 +58,11 @@ def pipeline(coassemblies, reads_1, reads_2, output_dir, threads, memory, fast=F
                 pl.lit("/recover"),
                 pl.when(pl.lit(fast)).then(pl.lit(" --workflow recover_mags_no_singlem --skip-binners maxbin concoct rosella --skip-abundances --refinery-max-iterations 0")).otherwise(pl.lit("")),
                 pl.lit(" -n "),
-                pl.lit(threads//2),
+                pl.lit(recover_threads),
                 pl.lit(" -t "),
-                pl.lit(threads//2),
+                pl.lit(recover_threads),
                 pl.lit(" -m "),
-                pl.lit(memory//2),
+                pl.lit(recover_memory),
                 pl.lit(" --skip-qc &> "),
                 pl.lit(output_dir),
                 pl.lit("/coassemble/logs/"),
@@ -94,8 +94,10 @@ if __name__ == "__main__":
         reads_1=snakemake.params.reads_1,
         reads_2=snakemake.params.reads_2,
         output_dir=snakemake.params.dir,
-        threads=snakemake.params.threads,
-        memory=snakemake.params.memory,
+        assemble_threads=snakemake.params.assemble_threads,
+        assemble_memory=snakemake.params.assemble_memory,
+        recover_threads=snakemake.params.recover_threads,
+        recover_memory=snakemake.params.recover_memory,
         fast=fast,
     )
 

--- a/test/data/mock_coassemble/config.yaml
+++ b/test/data/mock_coassemble/config.yaml
@@ -28,8 +28,10 @@ aviary_speed: fast
 run_aviary: false
 aviary_gtdbtk: gtdb_release
 aviary_checkm2: CheckM2_database
-aviary_memory: 500
-aviary_threads: 64
+aviary_assemble_memory: 500
+aviary_assemble_threads: 64
+aviary_recover_memory: 500
+aviary_recover_threads: 64
 test: false
 mock_sra: false
 aviary_dryrun: false

--- a/test/test_aviary_commands.py
+++ b/test/test_aviary_commands.py
@@ -47,8 +47,10 @@ class Tests(unittest.TestCase):
             ["4,5,6", 3, 1, 3000, "4,5,6", "coassembly_2"],
         ], schema=ELUSIVE_CLUSTERS_COLUMNS)
         output_dir = "test_output_dir"
-        threads = 10
-        memory = 50
+        assemble_threads = 10
+        assemble_memory = 50
+        recover_threads = 5
+        recover_memory = 25
 
 
         expected_commands = pl.DataFrame([
@@ -57,14 +59,14 @@ class Tests(unittest.TestCase):
                 f"-1 1_1.fq.gz 2_1.fq.gz 3_1.fq.gz "
                 f"-2 1_2.fq.gz 2_2.fq.gz 3_2.fq.gz "
                 f"--output {output_dir}/coassemble/coassembly_0/assemble "
-                f"-n {threads} -t {threads} -m {memory} --skip-qc "
+                f"-n {assemble_threads} -t {assemble_threads} -m {assemble_memory} --skip-qc "
                 f"&> {output_dir}/coassemble/logs/coassembly_0_assemble.log ",
 
                 f"aviary recover --assembly {output_dir}/coassemble/coassembly_0/assemble/assembly/final_contigs.fasta "
                 f"-1 1_1.fq.gz 2_1.fq.gz 3_1.fq.gz 4_1.fq.gz 5_1.fq.gz 6_1.fq.gz "
                 f"-2 1_2.fq.gz 2_2.fq.gz 3_2.fq.gz 4_2.fq.gz 5_2.fq.gz 6_2.fq.gz "
                 f"--output {output_dir}/coassemble/coassembly_0/recover "
-                f"-n {threads//2} -t {threads//2} -m {memory//2} --skip-qc "
+                f"-n {recover_threads} -t {recover_threads} -m {recover_memory} --skip-qc "
                 f"&> {output_dir}/coassemble/logs/coassembly_0_recover.log ",
             ],
             [
@@ -72,19 +74,19 @@ class Tests(unittest.TestCase):
                 f"-1 4_1.fq.gz 5_1.fq.gz 6_1.fq.gz "
                 f"-2 4_2.fq.gz 5_2.fq.gz 6_2.fq.gz "
                 f"--output {output_dir}/coassemble/coassembly_2/assemble "
-                f"-n {threads} -t {threads} -m {memory} --skip-qc "
+                f"-n {assemble_threads} -t {assemble_threads} -m {assemble_memory} --skip-qc "
                 f"&> {output_dir}/coassemble/logs/coassembly_2_assemble.log ",
 
                 f"aviary recover --assembly {output_dir}/coassemble/coassembly_2/assemble/assembly/final_contigs.fasta "
                 f"-1 4_1.fq.gz 5_1.fq.gz 6_1.fq.gz "
                 f"-2 4_2.fq.gz 5_2.fq.gz 6_2.fq.gz "
                 f"--output {output_dir}/coassemble/coassembly_2/recover "
-                f"-n {threads//2} -t {threads//2} -m {memory//2} --skip-qc "
+                f"-n {recover_threads} -t {recover_threads} -m {recover_memory} --skip-qc "
                 f"&> {output_dir}/coassemble/logs/coassembly_2_recover.log ",
             ],
         ], schema=COMMANDS_COLUMNS, orient="row")
 
-        observed_commands = pipeline(elusive_clusters, reads_1, reads_2, output_dir, threads, memory)
+        observed_commands = pipeline(elusive_clusters, reads_1, reads_2, output_dir, assemble_threads, assemble_memory, recover_threads, recover_memory)
         self.assertDataFrameEqual(expected_commands, observed_commands)
 
     def test_aviary_commands_fast(self):
@@ -93,8 +95,10 @@ class Tests(unittest.TestCase):
             ["4,5,6", 3, 1, 3000, "4,5,6", "coassembly_2"],
         ], schema=ELUSIVE_CLUSTERS_COLUMNS)
         output_dir = "test_output_dir"
-        threads = 10
-        memory = 50
+        assemble_threads = 10
+        assemble_memory = 50
+        recover_threads = 5
+        recover_memory = 25
 
 
         expected_commands = pl.DataFrame([
@@ -103,7 +107,7 @@ class Tests(unittest.TestCase):
                 f"-1 1_1.fq.gz 2_1.fq.gz 3_1.fq.gz "
                 f"-2 1_2.fq.gz 2_2.fq.gz 3_2.fq.gz "
                 f"--output {output_dir}/coassemble/coassembly_0/assemble "
-                f"-n {threads} -t {threads} -m {memory} --skip-qc "
+                f"-n {assemble_threads} -t {assemble_threads} -m {assemble_memory} --skip-qc "
                 f"&> {output_dir}/coassemble/logs/coassembly_0_assemble.log ",
 
                 f"aviary recover --assembly {output_dir}/coassemble/coassembly_0/assemble/assembly/final_contigs.fasta "
@@ -114,7 +118,7 @@ class Tests(unittest.TestCase):
                 f"--skip-binners maxbin concoct rosella "
                 f"--skip-abundances "
                 f"--refinery-max-iterations 0 "
-                f"-n {threads//2} -t {threads//2} -m {memory//2} --skip-qc "
+                f"-n {recover_threads} -t {recover_threads} -m {recover_memory} --skip-qc "
                 f"&> {output_dir}/coassemble/logs/coassembly_0_recover.log ",
             ],
             [
@@ -122,7 +126,7 @@ class Tests(unittest.TestCase):
                 f"-1 4_1.fq.gz 5_1.fq.gz 6_1.fq.gz "
                 f"-2 4_2.fq.gz 5_2.fq.gz 6_2.fq.gz "
                 f"--output {output_dir}/coassemble/coassembly_2/assemble "
-                f"-n {threads} -t {threads} -m {memory} --skip-qc "
+                f"-n {assemble_threads} -t {assemble_threads} -m {assemble_memory} --skip-qc "
                 f"&> {output_dir}/coassemble/logs/coassembly_2_assemble.log ",
 
                 f"aviary recover --assembly {output_dir}/coassemble/coassembly_2/assemble/assembly/final_contigs.fasta "
@@ -133,12 +137,12 @@ class Tests(unittest.TestCase):
                 f"--skip-binners maxbin concoct rosella "
                 f"--skip-abundances "
                 f"--refinery-max-iterations 0 "
-                f"-n {threads//2} -t {threads//2} -m {memory//2} --skip-qc "
+                f"-n {recover_threads} -t {recover_threads} -m {recover_memory} --skip-qc "
                 f"&> {output_dir}/coassemble/logs/coassembly_2_recover.log ",
             ],
         ], schema=COMMANDS_COLUMNS, orient="row")
 
-        observed_commands = pipeline(elusive_clusters, reads_1, reads_2, output_dir, threads, memory, fast=True)
+        observed_commands = pipeline(elusive_clusters, reads_1, reads_2, output_dir, assemble_threads, assemble_memory, recover_threads, recover_memory, fast=True)
         self.assertDataFrameEqual(expected_commands, observed_commands)
 
 

--- a/test/test_coassemble.py
+++ b/test/test_coassemble.py
@@ -801,6 +801,7 @@ class Tests(unittest.TestCase):
             self.assertEqual(config["aviary_threads"], 64)
             self.assertEqual(config["aviary_memory"], 500)
             self.assertEqual(config["coassembly_samples"], [])
+            self.assertEqual(config["assembly_strategy"], "dynamic")
 
     def test_coassemble_singlem_inputs(self):
         with in_tempdir():
@@ -982,6 +983,7 @@ class Tests(unittest.TestCase):
                 f"--coassembly-samples-list coassembly_samples "
                 f"--exclude-coassemblies-list exclude_coassemblies "
                 f"--assemble-unmapped "
+                f"--assembly-strategy megahit "
                 f"--output test "
                 f"--conda-prefix {path_to_conda} "
                 f"--dryrun "
@@ -1011,6 +1013,7 @@ class Tests(unittest.TestCase):
             self.assertEqual(config["exclude_coassemblies"], ["sample_1,sample_2"])
             self.assertEqual(config["reads_1"], {os.path.splitext(os.path.splitext(os.path.basename(s))[0])[0]: s for s in SAMPLE_READS_FORWARD.split(" ")})
             self.assertEqual(config["reads_2"], {os.path.splitext(os.path.splitext(os.path.basename(s))[0])[0]: s for s in SAMPLE_READS_REVERSE.split(" ")})
+            self.assertEqual(config["assembly_strategy"], "megahit")
 
     def test_coassemble_singlem_inputs_files_of_paths(self):
         with in_tempdir():

--- a/test/test_coassemble.py
+++ b/test/test_coassemble.py
@@ -798,8 +798,10 @@ class Tests(unittest.TestCase):
             self.assertEqual(config["max_threads"], 8)
             self.assertEqual(config["taxa_of_interest"], "")
             self.assertEqual(config["assemble_unmapped"], False)
-            self.assertEqual(config["aviary_threads"], 64)
-            self.assertEqual(config["aviary_memory"], 500)
+            self.assertEqual(config["aviary_assemble_threads"], 64)
+            self.assertEqual(config["aviary_assemble_memory"], 500)
+            self.assertEqual(config["aviary_recover_threads"], 64)
+            self.assertEqual(config["aviary_recover_memory"], 500)
             self.assertEqual(config["coassembly_samples"], [])
             self.assertEqual(config["assembly_strategy"], "dynamic")
 

--- a/test/test_coassemble.py
+++ b/test/test_coassemble.py
@@ -800,8 +800,8 @@ class Tests(unittest.TestCase):
             self.assertEqual(config["assemble_unmapped"], False)
             self.assertEqual(config["aviary_assemble_threads"], 64)
             self.assertEqual(config["aviary_assemble_memory"], 500)
-            self.assertEqual(config["aviary_recover_threads"], 64)
-            self.assertEqual(config["aviary_recover_memory"], 500)
+            self.assertEqual(config["aviary_recover_threads"], 32)
+            self.assertEqual(config["aviary_recover_memory"], 250)
             self.assertEqual(config["coassembly_samples"], [])
             self.assertEqual(config["assembly_strategy"], "dynamic")
 

--- a/test/test_iterate.py
+++ b/test/test_iterate.py
@@ -352,8 +352,8 @@ class Tests(unittest.TestCase):
             self.assertEqual(config["assemble_unmapped"], False)
             self.assertEqual(config["aviary_assemble_threads"], 64)
             self.assertEqual(config["aviary_assemble_memory"], 500)
-            self.assertEqual(config["aviary_recover_threads"], 64)
-            self.assertEqual(config["aviary_recover_memory"], 500)
+            self.assertEqual(config["aviary_recover_threads"], 32)
+            self.assertEqual(config["aviary_recover_memory"], 250)
             self.assertEqual(config["exclude_coassemblies"], ["sample_0,sample_1", "sample_4,sample_5"])
 
             self.assertTrue("Evaluating bins using CheckM2 with completeness >= 70 and contamination <= 10" in output)

--- a/test/test_iterate.py
+++ b/test/test_iterate.py
@@ -350,8 +350,10 @@ class Tests(unittest.TestCase):
             self.assertEqual(config["max_threads"], 8)
             self.assertEqual(config["taxa_of_interest"], "")
             self.assertEqual(config["assemble_unmapped"], False)
-            self.assertEqual(config["aviary_threads"], 64)
-            self.assertEqual(config["aviary_memory"], 500)
+            self.assertEqual(config["aviary_assemble_threads"], 64)
+            self.assertEqual(config["aviary_assemble_memory"], 500)
+            self.assertEqual(config["aviary_recover_threads"], 64)
+            self.assertEqual(config["aviary_recover_memory"], 500)
             self.assertEqual(config["exclude_coassemblies"], ["sample_0,sample_1", "sample_4,sample_5"])
 
             self.assertTrue("Evaluating bins using CheckM2 with completeness >= 70 and contamination <= 10" in output)


### PR DESCRIPTION
- [x] Add `assembly-strategy` argument to define if dynamic (current) or metaspades/megahit only
- [x] Split assembly/recovery cpu/memory arguments