### PR TITLE
Update Aviary

### DIFF
--- a/binchicken/binchicken.py
+++ b/binchicken/binchicken.py
@@ -928,6 +928,7 @@ def build(args):
     args.new_genomes_list = None
     args.coassembly_samples_list = None
     args.sample_read_size = None
+    args.cluster_submission = False
     args.aviary_gtdbtk_db = "."
     args.aviary_checkm2_db = "."
     args.aviary_assemble_cores = None

--- a/binchicken/binchicken.py
+++ b/binchicken/binchicken.py
@@ -476,6 +476,7 @@ def coassemble(args):
         "aviary_speed": args.aviary_speed,
         "assembly_strategy": args.assembly_strategy,
         "run_aviary": args.run_aviary,
+        "cluster_submission": args.cluster_submission,
         "aviary_gtdbtk": args.aviary_gtdbtk_db,
         "aviary_checkm2": args.aviary_checkm2_db,
         "aviary_assemble_threads": args.aviary_assemble_cores,
@@ -1133,6 +1134,7 @@ def main():
 
     def add_aviary_options(argument_group):
         argument_group.add_argument("--run-aviary", action="store_true", help="Run Aviary commands for all identified coassemblies (unless specific coassemblies are chosen with --coassemblies) [default: do not]")
+        argument_group.add_argument("--cluster-submission", action="store_true", help="Flag that cluster submission will occur through `--snakemake-profile`. This sets the local threads of Aviary recover to 1, allowing parallel job submission [default: do not]")
         default_aviary_speed = FAST_AVIARY_MODE
         argument_group.add_argument("--aviary-speed", help=f"Run Aviary recover in 'fast' or 'comprehensive' mode. Fast mode skips slow binners and refinement steps. [default: {default_aviary_speed}]",
                                     default=default_aviary_speed, choices=[FAST_AVIARY_MODE, COMPREHENSIVE_AVIARY_MODE])
@@ -1378,6 +1380,8 @@ def main():
                 raise Exception("Max recovery samples (--max-recovery-samples) must be greater than or equal to number of coassembly samples (--num-coassembly-samples)")
         if args.run_aviary and not (args.aviary_gtdbtk_db and args.aviary_checkm2_db):
             raise Exception("Run Aviary (--run-aviary) requires paths to GTDB-Tk and CheckM2 databases to be provided (--aviary-gtdbtk-db or GTDBTK_DATA_PATH and --aviary-checkm2-db or CHECKM2DB)")
+        if args.cluster_submission and not args.snakemake_profile:
+                logging.warning("The arg `--cluster-submission` is only a flag and cannot activate cluster submission alone. Please see `--snakemake-profile` for cluster submission.")
         if (args.sample_query or args.sample_query_list or args.sample_query_dir) and args.taxa_of_interest and args.assemble_unmapped:
             raise Exception("Unmapping is incompatible with the combination of sample query and taxa of interest")
 
@@ -1407,6 +1411,8 @@ def main():
         coassemble_output_argument_verification(args)
         if args.run_aviary and not (args.aviary_gtdbtk_db and args.aviary_checkm2_db):
             raise Exception("Run Aviary (--run-aviary) requires paths to GTDB-Tk and CheckM2 databases to be provided (--aviary-gtdbtk-db and --aviary-checkm2-db)")
+        if args.cluster_submission and not args.snakemake_profile:
+            logging.warning("The arg `--cluster-submission` is only a flag and cannot activate cluster submission alone. Please see `--snakemake-profile` for cluster submission.")
         update(args)
 
     elif args.subparser_name == "iterate":

--- a/binchicken/config/template_coassemble.yaml
+++ b/binchicken/config/template_coassemble.yaml
@@ -24,6 +24,7 @@ unmapping_max_alignment: 1
 aviary_speed: "fast"
 assembly_strategy: "dynamic"
 run_aviary: false
+cluster_submission: false
 aviary_gtdbtk: ""
 aviary_checkm2: ""
 aviary_assemble_memory: 1

--- a/binchicken/workflow/coassemble.smk
+++ b/binchicken/workflow/coassemble.smk
@@ -747,9 +747,10 @@ rule aviary_recover:
         snakemake_profile = f"--snakemake-profile {config['snakemake_profile']}" if config["snakemake_profile"] else "",
         cluster_retries = f"--cluster-retries {config['cluster_retries']}" if config["cluster_retries"] else "",
         tmpdir = f"TMPDIR={config['tmpdir']}" if config["tmpdir"] else "",
+        threads = int(config["aviary_recover_threads"])
     localrule: True
     threads:
-        int(config["aviary_recover_threads"])
+        1 if config["cluster_submission"] else int(config["aviary_recover_threads"])
     resources:
         mem_mb = int(config["aviary_recover_memory"])*1000,
         mem_gb = int(config["aviary_recover_memory"]),
@@ -771,12 +772,12 @@ rule aviary_recover:
         "-2 {params.reads_2} "
         "--output {params.output} "
         "{params.fast} "
-        "-n {threads} "
-        "-t {threads} "
+        "-n {params.threads} "
+        "-t {params.threads} "
         "-m {resources.mem_gb} "
         "--skip-qc "
         "{params.snakemake_profile} "
-        "{params.cluster_retries} "
+        "{params.retries} "
         "{params.dryrun} "
         "&> {log} "
         "&& touch {output} "

--- a/binchicken/workflow/coassemble.smk
+++ b/binchicken/workflow/coassemble.smk
@@ -743,7 +743,7 @@ rule aviary_recover:
         checkm2 = config["aviary_checkm2"],
         conda_prefix = config["conda_prefix"] if config["conda_prefix"] else ".",
         singlem_metapackage = config["singlem_metapackage"],
-        fast = "--workflow recover_mags_no_singlem --skip-binners maxbin concoct rosella --skip-abundances --refinery-max-iterations 0" if config["aviary_speed"] == FAST_AVIARY_MODE else "",
+        fast = "--workflow recover_mags_no_singlem --skip-abundances --refinery-max-iterations 0" if config["aviary_speed"] == FAST_AVIARY_MODE else "",
         snakemake_profile = f"--snakemake-profile {config['snakemake_profile']}" if config["snakemake_profile"] else "",
         cluster_retries = f"--cluster-retries {config['cluster_retries']}" if config["cluster_retries"] else "",
         tmpdir = f"TMPDIR={config['tmpdir']}" if config["tmpdir"] else "",

--- a/binchicken/workflow/coassemble.smk
+++ b/binchicken/workflow/coassemble.smk
@@ -777,7 +777,7 @@ rule aviary_recover:
         "-m {resources.mem_gb} "
         "--skip-qc "
         "{params.snakemake_profile} "
-        "{params.retries} "
+        "{params.cluster_retries} "
         "{params.dryrun} "
         "&> {log} "
         "&& touch {output} "

--- a/binchicken/workflow/coassemble.smk
+++ b/binchicken/workflow/coassemble.smk
@@ -743,7 +743,7 @@ rule aviary_recover:
         checkm2 = config["aviary_checkm2"],
         conda_prefix = config["conda_prefix"] if config["conda_prefix"] else ".",
         singlem_metapackage = config["singlem_metapackage"],
-        fast = "--workflow recover_mags_no_singlem --skip-abundances --refinery-max-iterations 0" if config["aviary_speed"] == FAST_AVIARY_MODE else "",
+        fast = "--skip-singlem --skip-abundances --refinery-max-iterations 0" if config["aviary_speed"] == FAST_AVIARY_MODE else "",
         snakemake_profile = f"--snakemake-profile {config['snakemake_profile']}" if config["snakemake_profile"] else "",
         cluster_retries = f"--cluster-retries {config['cluster_retries']}" if config["cluster_retries"] else "",
         tmpdir = f"TMPDIR={config['tmpdir']}" if config["tmpdir"] else "",

--- a/binchicken/workflow/env/aviary.yml
+++ b/binchicken/workflow/env/aviary.yml
@@ -2,4 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - aviary=0.8.*
+  - aviary=0.9.*

--- a/docs/preludes/coassemble_prelude.md
+++ b/docs/preludes/coassemble_prelude.md
@@ -36,7 +36,13 @@ Important options:
   - Run coassemblies with differential-abudance-binning samples with the tool of your choice (see `coassemble/target/elusive_clusters.tsv` in output)
 - The taxa of the considered sequences can be filtered to target a specific taxon (e.g. `--taxa-of-interest "p__Planctomycetota"`).
 - Differential-abundance binning samples for single-assembly can also be found (`--single-assembly`)
-- Snakemake profiles can be used to automatically submit jobs to HPC clusters (`--snakemake-profile`)
 
 Paired end reads of form reads_1.1.fq, reads_1_1.fq and reads_1_R1.fq, where reads_1 is the sample name are automatically detected and matched to their basename.
 Most intermediate files can be provided to skip intermediate steps (e.g. SingleM otu tables, read sizes or genome transcripts; see `binchicken coassemble --full-help`).
+
+## Cluster submission
+
+Snakemake profiles can be used to automatically submit jobs to HPC clusters (`--snakemake-profile`).
+Note that Aviary assemble commands are submitted to the cluster, while Aviary recover commands are run locally such that Aviary handles cluster submission.
+The `--cluster-submission` flag sets the local Aviary recover thread usage to 1, to enable multiple runs in parallel within `--local-cores`.
+This is required to prevent `--local-cores` from limiting the number of threads per submitted job.

--- a/docs/preludes/coassemble_prelude.md
+++ b/docs/preludes/coassemble_prelude.md
@@ -21,7 +21,7 @@ binchicken coassemble --forward reads_1.1.fq ... --reverse reads_1.2.fq ... --si
 # Create snakemake profile at ~/.config/snakemake/qsub with cluster, cluster-status, cluster-cancel, etc.
 # See https://snakemake.readthedocs.io/en/stable/executing/cli.html#profiles
 binchicken coassemble --forward reads_1.1.fq ... --reverse reads_1.2.fq ... --run-aviary \
-  --snakemake-profile qsub --local-cores 64 --cores 64
+  --snakemake-profile qsub --cluster-submission --local-cores 64 --cores 64
 ```
 
 Important options:

--- a/test/test_manual.py
+++ b/test/test_manual.py
@@ -26,7 +26,7 @@ TWO_GENOMES = " ".join([
     os.path.join(path_to_data, "GB_GCA_013286235.2.fna"),
     ])
 
-MOCK_COASSEMBLE = os.path.join(path_to_data, "mock_coassemble")
+MOCK_COASSEMBLE = os.path.join(path_to_data, "mock_coassemble", "coassemble")
 APPRAISE_BINNED = os.path.join(MOCK_COASSEMBLE, "coassemble", "appraise", "binned.otu_table.tsv")
 APPRAISE_UNBINNED = os.path.join(MOCK_COASSEMBLE, "coassemble", "appraise", "unbinned.otu_table.tsv")
 ELUSIVE_CLUSTERS = os.path.join(MOCK_COASSEMBLE, "coassemble", "target", "elusive_clusters.tsv")

--- a/test/test_manual.py
+++ b/test/test_manual.py
@@ -140,7 +140,10 @@ class Tests(unittest.TestCase):
             f"--coassemble-summary {os.path.join(MOCK_COASSEMBLE, 'summary.tsv')} "
             f"--output {output_dir} "
             f"--conda-prefix {path_to_conda} "
-            f"--snakemake-args '--profile mqsub --retries 1' "
+            f"--snakemake-profile mqsub "
+            f"--local-cores 5 "
+            f"--cluster-retries 1 "
+            f"--cluster-submission "
         )
         subprocess.run(cmd, shell=True, check=True)
 

--- a/test/test_manual.py
+++ b/test/test_manual.py
@@ -102,6 +102,7 @@ class Tests(unittest.TestCase):
             f"--snakemake-profile mqsub "
             f"--local-cores 5 "
             f"--cluster-retries 1 "
+            f"--cluster-submission "
         )
         subprocess.run(cmd, shell=True, check=True)
 


### PR DESCRIPTION
- [x] v0.9.*
- [x] Properly set cores and local cores
  - [x] Add `--cluster-submission` argument that sets Aviary recovery parent command threads to 1 (while allowing larger jobs to be submitted to the cluster)