### PR TITLE
Allow normal regex for taxa-of-interest argument

### DIFF
--- a/binchicken/binchicken.py
+++ b/binchicken/binchicken.py
@@ -1324,7 +1324,7 @@ def main():
         coassemble_midpoint.add_argument("--genome-singlem", help="Combined SingleM otu tables for genome transcripts. If provided, genome SingleM is skipped")
         # Clustering options
         coassemble_clustering = parser.add_argument_group("Clustering options")
-        coassemble_clustering.add_argument("--taxa-of-interest", help="Only consider sequences from this GTDB taxa (e.g. p__Planctomycetota) [default: all]")
+        coassemble_clustering.add_argument("--taxa-of-interest", help="Only consider sequences from this GTDB taxa (e.g. p__Planctomycetota, or 'p__Bacillota|p__Bacteroidota') [default: all]")
         appraise_sequence_identity_default = 0.96
         coassemble_clustering.add_argument("--appraise-sequence-identity", type=int, help=f"Minimum sequence identity for SingleM appraise against reference database. e.g. 96% for Species-level or 86% Genus-level [default: {appraise_sequence_identity_default}]", default=appraise_sequence_identity_default)
         min_sequence_coverage_default = 10

--- a/binchicken/workflow/scripts/sketch_samples.py
+++ b/binchicken/workflow/scripts/sketch_samples.py
@@ -83,7 +83,7 @@ if __name__ == "__main__":
     if TAXA_OF_INTEREST:
         logging.info(f"Filtering for taxa of interest: {TAXA_OF_INTEREST}")
         unbinned = unbinned.filter(
-            pl.col("taxonomy").str.contains(TAXA_OF_INTEREST, literal=True)
+            pl.col("taxonomy").str.contains(TAXA_OF_INTEREST)
         )
 
     signatures = processing(unbinned, output_path, threads=threads)

--- a/binchicken/workflow/scripts/target_elusive.py
+++ b/binchicken/workflow/scripts/target_elusive.py
@@ -122,7 +122,7 @@ def streaming_pipeline(
     if TAXA_OF_INTEREST:
         logging.info(f"Filtering for taxa of interest: {TAXA_OF_INTEREST}")
         unbinned = unbinned.filter(
-            pl.col("taxonomy").str.contains(TAXA_OF_INTEREST, literal=True)
+            pl.col("taxonomy").str.contains(TAXA_OF_INTEREST)
         )
 
     logging.info("Grouping hits by marker gene sequences to form targets")
@@ -208,7 +208,7 @@ def pipeline(
     if TAXA_OF_INTEREST:
         logging.info(f"Filtering for taxa of interest: {TAXA_OF_INTEREST}")
         unbinned = unbinned.filter(
-            pl.col("taxonomy").str.contains(TAXA_OF_INTEREST, literal=True)
+            pl.col("taxonomy").str.contains(TAXA_OF_INTEREST)
         )
 
     logging.info("Grouping hits by marker gene sequences to form targets")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = ["snakemake>=6.0.5",
   "bird_tool_utils",
   "extern",
   "ruamel.yaml>=0.15.99",
-  "polars=1.2.1",
+  "polars",
   "pyarrow"]
 classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = ["snakemake>=6.0.5",
   "bird_tool_utils",
   "extern",
   "ruamel.yaml>=0.15.99",
-  "polars=1.2.*",
+  "polars=1.2.1",
   "pyarrow"]
 classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics",

--- a/test/test_target_elusive.py
+++ b/test/test_target_elusive.py
@@ -679,6 +679,27 @@ class Tests(unittest.TestCase):
         self.assertDataFrameEqual(expected_targets, observed_targets)
         self.assertDataFrameEqual(expected_edges, observed_edges)
 
+    def test_target_elusive_target_taxa_multiple(self):
+        unbinned = pl.DataFrame([
+            ["S3.1", "sample_1", "AAA", 5, 10, "Root; d__Bacteria; p__Planctomycetota", ""],
+            ["S3.1", "sample_1", "AAB", 5, 10, "Root", ""],
+            ["S3.1", "sample_2", "AAA", 5, 10, "Root; d__Bacteria; p__Pseudomonadota", ""],
+            ["S3.1", "sample_2", "AAB", 5, 10, "Root", ""],
+        ], orient="row", schema=APPRAISE_COLUMNS)
+        samples = set(["sample_1", "sample_2"])
+
+        expected_targets = pl.DataFrame([
+            ["S3.1", "sample_1", "AAA", 5, 10, "Root; d__Bacteria; p__Planctomycetota", "0"],
+            ["S3.1", "sample_2", "AAA", 5, 10, "Root; d__Bacteria; p__Pseudomonadota", "0"],
+        ], orient="row", schema=TARGETS_COLUMNS)
+        expected_edges = pl.DataFrame([
+            ["match", 2, "sample_1,sample_2", "0"],
+        ], orient="row", schema=EDGES_COLUMNS)
+
+        observed_targets, observed_edges = pipeline(unbinned, samples, TAXA_OF_INTEREST="p__Planctomycetota|p__Pseudomonadota")
+        self.assertDataFrameEqual(expected_targets, observed_targets)
+        self.assertDataFrameEqual(expected_edges, observed_edges)
+
     def test_target_elusive_single_assembly(self):
         unbinned = pl.DataFrame([
             ["S3.1", "sample_1", "AAA", 5, 10, "Root", ""],


### PR DESCRIPTION
Allows the use of `|`, etc