### PR TITLE
Fix enumeration of all combinations before filtering to top 100

### DIFF
--- a/.github/workflows/test-binchicken.yml
+++ b/.github/workflows/test-binchicken.yml
@@ -19,7 +19,6 @@ jobs:
           activate-environment: test
           environment-file: binchicken.yml
           python-version: ${{ matrix.python-version }}
-          miniforge-variant: Mambaforge
           auto-activate-base: false
           channels: conda-forge,bioconda
           channel-priority: true

--- a/binchicken/workflow/scripts/target_elusive.py
+++ b/binchicken/workflow/scripts/target_elusive.py
@@ -68,7 +68,7 @@ def get_clusters(
         # Choose top N clusters for each cluster size where N is PRECLUSTER_SIZE
         .with_columns(
             sample_combinations = pl.col("cluster_size").map_elements(
-                lambda x: [[0] + list(i) for i in itertools.combinations(range(1, PRECLUSTER_SIZE), x)][:PRECLUSTER_SIZE],
+                lambda x: [[0] + list(i) for i in itertools.islice(itertools.combinations(range(1, PRECLUSTER_SIZE), x), PRECLUSTER_SIZE)],
                 return_dtype=pl.List(pl.List(pl.Int64)),
                 )
             )


### PR DESCRIPTION
Combinations were enumerated into list before filtering down
Only becomes an issue with cluster_size >5