### PR TITLE
Use unique log paths per attempt

### DIFF
--- a/binchicken/common.py
+++ b/binchicken/common.py
@@ -2,6 +2,7 @@ import os
 import importlib.resources
 import re
 import ast
+import time
 
 def fasta_to_name(filename):
     sample_name = os.path.basename(filename)
@@ -31,3 +32,32 @@ def pixi_run_func():
         return f"pixi run --frozen --manifest-path {manifest_path}"
 
 pixi_run = pixi_run_func()
+
+
+# A unique identifier for the current workflow invocation. This is used
+# when creating log directories so that retries from the same workflow do
+# not overwrite previous log files.
+workflow_identifier = time.strftime("%Y%m%d_%H%M%S")
+
+
+def setup_log(log_dir_base: str, attempt: int) -> str:
+    """Return a unique log file path for a given rule attempt.
+
+    Parameters
+    ----------
+    log_dir_base: str
+        Directory in which log files for a rule should be stored.  This
+        function will create a subdirectory named with the workflow
+        identifier and place attempt specific log files inside it.
+    attempt: int
+        The Snakemake retry attempt number.
+
+    Returns
+    -------
+    str
+        Path to a log file unique to the workflow invocation and attempt.
+    """
+
+    log_dir = os.path.join(log_dir_base, workflow_identifier)
+    os.makedirs(log_dir, exist_ok=True)
+    return os.path.join(log_dir, f"attempt{attempt}.log")

--- a/binchicken/workflow/coassemble.smk
+++ b/binchicken/workflow/coassemble.smk
@@ -502,7 +502,7 @@ rule no_genomes:
         "--binned {output.binned} "
         "--unbinned {output.unbinned} "
         "--threads {threads} "
-        "--log {resources.log_path}"
+        "&> {resources.log_path}"
 
 ######################
 ### Target elusive ###

--- a/binchicken/workflow/download.smk
+++ b/binchicken/workflow/download.smk
@@ -3,7 +3,7 @@
 #############
 import os
 import polars as pl
-from binchicken.common import pixi_run
+from binchicken.common import pixi_run, setup_log
 os.umask(0o002)
 
 output_dir = os.path.abspath("download")
@@ -55,8 +55,7 @@ rule aviary_download:
     resources:
         mem_mb=get_mem_mb,
         runtime = get_runtime(base_hours = 16),
-    log:
-        logs_dir + "/aviary_downloads.log"
+        log_path=lambda wildcards, attempt: setup_log(f"{logs_dir}/aviary_downloads", attempt)
     shell:
         "{params.tmpdir} "
         "{params.singlem_metapackage_env} "
@@ -69,5 +68,5 @@ rule aviary_download:
         "{params.checkm2_db} "
         "{params.gtdbtk_db} "
         "{params.download_arg} "
-        "&> {log} "
+        "&> {resources.log_path} "
         "&& touch {output} "


### PR DESCRIPTION
log directives can't take a lambda, and attempt number is not available (directly) in shell commands. So have to resort to using resources.

It isn't the best solution because when the rule fails, snakemake no longer suggests the user look at the log file.

One option was to also specify the log directive so it at least points at the directory where the log file is, which is consistent between attempts. But the problem is that for some reason I can't understand snakemake seems to delete the folder when log and resources are specified.

A frustrating search to implement what should be simple - log directives should take a lambda I reckon. Maybe there's some complexity I don't understand.