### PR TITLE
Fix single target counts being incorrect

### DIFF
--- a/binchicken/workflow/scripts/cluster_graph.py
+++ b/binchicken/workflow/scripts/cluster_graph.py
@@ -164,15 +164,16 @@ def pipeline(
                     )
                 .with_columns(
                     source_sample = pl.col("samples").list.first(),
-                    dest_sample = pl.col("samples").list.get(1),
+                    dest_sample = pl.col("samples").list.get(1, null_on_oob=True),
                     samples_hash = pl.col("samples").list.sort().hash(),
                     length = pl.col("samples").list.len()
                     )
             )
 
             directional_rows = elusive_edges.filter(pl.col("style") == "directional").height
-            if directional_rows == 0:
-                raise ValueError("Directional edges now required for single-sample clusters. Please rerun with a clean output folder.")
+            singleton_rows = elusive_edges.filter(pl.col("style") == "singleton").height
+            if directional_rows == 0 and singleton_rows == 0:
+                raise ValueError("Directional or singleton edges required for single-sample clusters. Please rerun with a clean output folder.")
         else:
             elusive_edges = (
                 elusive_edges
@@ -295,6 +296,7 @@ def pipeline(
             sample_targets = (
                 elusive_edges
                 .select("target_ids", recover_candidates = pl.col("dest_sample"))
+                .filter(pl.col("recover_candidates").is_not_null())
                 .explode("target_ids")
                 .unique()
                 .group_by("recover_candidates")
@@ -374,7 +376,7 @@ def pipeline(
                     .then(pl.col("total_targets"))
                     .otherwise(pl.col("target_ids").list.len()),
                 )
-            .sort("total_targets", "total_size", descending=[True, False])
+            .sort("total_targets", "total_size", "samples", descending=[True, False, True])
             .with_row_index("coassembly")
             .select(
                 "samples", "length", "total_targets", "total_size", "recover_samples",

--- a/binchicken/workflow/scripts/cluster_graph.py
+++ b/binchicken/workflow/scripts/cluster_graph.py
@@ -151,21 +151,44 @@ def pipeline(
     is_pooled = any(elusive_edges["style"] == "pool")
 
     with pl.StringCache():
-        elusive_edges = (
-            elusive_edges
-            .with_columns(
-                pl.col("samples")
-                    .str.split(",")
-                    .cast(pl.List(pl.Categorical)),
-                pl.col("target_ids")
-                    .str.split(",")
-                    .cast(pl.List(pl.UInt64)),
-                )
-            .with_columns(
-                samples_hash = pl.col("samples").list.sort().hash(),
-                length = pl.col("samples").list.len()
-                )
-        )
+        if MAX_COASSEMBLY_SAMPLES == 1:
+            elusive_edges = (
+                elusive_edges
+                .with_columns(
+                    pl.col("samples")
+                        .str.split(",")
+                        .cast(pl.List(pl.Categorical)),
+                    pl.col("target_ids")
+                        .str.split(",")
+                        .cast(pl.List(pl.UInt64)),
+                    )
+                .with_columns(
+                    source_sample = pl.col("samples").list.first(),
+                    dest_sample = pl.col("samples").list.get(1),
+                    samples_hash = pl.col("samples").list.sort().hash(),
+                    length = pl.col("samples").list.len()
+                    )
+            )
+
+            directional_rows = elusive_edges.filter(pl.col("style") == "directional").height
+            if directional_rows == 0:
+                raise ValueError("Directional edges now required for single-sample clusters. Please rerun with a clean output folder.")
+        else:
+            elusive_edges = (
+                elusive_edges
+                .with_columns(
+                    pl.col("samples")
+                        .str.split(",")
+                        .cast(pl.List(pl.Categorical)),
+                    pl.col("target_ids")
+                        .str.split(",")
+                        .cast(pl.List(pl.UInt64)),
+                    )
+                .with_columns(
+                    samples_hash = pl.col("samples").list.sort().hash(),
+                    length = pl.col("samples").list.len()
+                    )
+            )
 
         if weightings is not None:
             if weightings.height == 0:
@@ -180,7 +203,12 @@ def pipeline(
         else:
             weightings_dict = {}
 
-        if COASSEMBLY_SAMPLES:
+        if COASSEMBLY_SAMPLES and MAX_COASSEMBLY_SAMPLES == 1:
+            coassembly_edges = (
+                elusive_edges
+                .filter(pl.col("source_sample").is_in(COASSEMBLY_SAMPLES))
+            )
+        elif COASSEMBLY_SAMPLES:
             coassembly_edges = (
                 elusive_edges
                 .with_columns(
@@ -217,14 +245,13 @@ def pipeline(
             logging.info("Skipping clustering, using single-sample clusters")
             clusters = [
                 elusive_edges
-                .explode("samples")
-                .filter((not COASSEMBLY_SAMPLES) | pl.col("samples").is_in(COASSEMBLY_SAMPLES))
-                .group_by("samples")
+                .filter((not COASSEMBLY_SAMPLES) | pl.col("source_sample").is_in(COASSEMBLY_SAMPLES))
+                .group_by("source_sample")
                 .agg(pl.col("target_ids").flatten())
                 .with_columns(
-                    pl.concat_list(pl.col("samples")),
-                    pl.col("target_ids").list.sort().list.unique(),
-                    samples_hash = pl.concat_list(pl.col("samples")).list.sort().hash(),
+                    samples = pl.concat_list(pl.col("source_sample")),
+                    target_ids = pl.col("target_ids").list.sort().list.unique(),
+                    samples_hash = pl.concat_list(pl.col("source_sample")).list.sort().hash(),
                 )
             ]
         else:
@@ -264,15 +291,25 @@ def pipeline(
                     .select("samples", "target_ids", "samples_hash")
                 )
 
-        sample_targets = (
-            elusive_edges
-            .select("target_ids", recover_candidates = pl.col("samples"))
-            .explode("recover_candidates")
-            .explode("target_ids")
-            .unique()
-            .group_by("recover_candidates")
-            .agg("target_ids")
-        )
+        if MAX_COASSEMBLY_SAMPLES == 1:
+            sample_targets = (
+                elusive_edges
+                .select("target_ids", recover_candidates = pl.col("dest_sample"))
+                .explode("target_ids")
+                .unique()
+                .group_by("recover_candidates")
+                .agg("target_ids")
+            )
+        else:
+            sample_targets = (
+                elusive_edges
+                .select("target_ids", recover_candidates = pl.col("samples"))
+                .explode("recover_candidates")
+                .explode("target_ids")
+                .unique()
+                .group_by("recover_candidates")
+                .agg("target_ids")
+            )
 
         def filter_max_coassembly_size(df, MAX_COASSEMBLY_SIZE):
             if MAX_COASSEMBLY_SIZE is None:

--- a/binchicken/workflow/scripts/target_elusive.py
+++ b/binchicken/workflow/scripts/target_elusive.py
@@ -5,6 +5,7 @@
 # Author: Samuel Aroney
 
 import os
+import glob
 import polars as pl
 import logging
 import numpy as np
@@ -214,10 +215,12 @@ def streaming_pipeline(
         return(sparse_edges)
 
     num_chunks = (sample_preclusters.height + CHUNK_SIZE - 1) // CHUNK_SIZE # Ceiling division to include all rows
-    # Check if any edges_path_* files exist and remove them
-    if os.path.exists(edges_path + "_*"):
+    # Remove any existing chunk files so stale data is not merged into output
+    chunk_paths = glob.glob(edges_path + "_*")
+    if chunk_paths:
         logging.info(f"Removing existing files: {edges_path}_*")
-        os.system(f"rm {edges_path}_*")
+        for chunk_path in chunk_paths:
+            os.remove(chunk_path)
 
     with pl.StringCache():
         logging.info("Processing clusters in chunks")

--- a/binchicken/workflow/scripts/target_elusive.py
+++ b/binchicken/workflow/scripts/target_elusive.py
@@ -49,6 +49,10 @@ def get_clusters(
     if sample_distances.height == 0:
         return pl.DataFrame(schema={"samples": str})
 
+    if MAX_COASSEMBLY_SAMPLES < 2:
+        # Set to 2 to produce paired edges
+        MAX_COASSEMBLY_SAMPLES = 2
+
     logging.info("Converting to sparse array")
     samples = np.unique(np.concatenate([
         sample_distances.select("query_name").to_numpy().flatten(),
@@ -180,64 +184,95 @@ def streaming_pipeline(
         pl.DataFrame(schema=EDGES_COLUMNS).write_csv(edges_path, separator="\t")
         return
 
-    if MAX_COASSEMBLY_SAMPLES == 1:
-        precluster_keys = []
-        if sample_preclusters.height > 0:
-            precluster_keys = (
-                sample_preclusters
-                .select(pl.col("samples").str.split(",").list.sort().list.join(",").alias("pair_key"))
-                .get_column("pair_key")
-                .to_list()
-            )
-
-        source = (
-            targets
-            .filter(pl.col("coverage") > MIN_COASSEMBLY_COVERAGE)
-            .select(
-                source_sample = pl.col("sample"),
-                target = pl.col("target"),
-                )
-            .unique()
-        )
-        dest = (
-            targets
-            .select(
-                dest_sample = pl.col("sample"),
-                target = pl.col("target"),
-                )
-            .unique()
-        )
-
-        directional_edges = (
-            source
-            .join(dest, on="target")
-            .filter(pl.col("source_sample") != pl.col("dest_sample"))
-        )
-        if precluster_keys:
-            directional_edges = directional_edges.filter(
-                pl.concat_list([pl.col("source_sample"), pl.col("dest_sample")])
-                .list.sort()
-                .list.join(",")
-                .is_in(precluster_keys)
-            )
-
-        (
-            directional_edges
-            .group_by("source_sample", "dest_sample")
-            .agg(target_ids = pl.col("target").cast(pl.Utf8).unique().sort().str.join(","))
-            .with_columns(
-                style = pl.lit("directional"),
-                cluster_size = pl.lit(2),
-                samples = pl.concat_str(["source_sample", "dest_sample"], separator=","),
-                )
-            .select("style", "cluster_size", "samples", "target_ids")
-            .sink_csv(edges_path, separator="\t")
-        )
-        return
-
     if sample_preclusters.height == 0:
         logging.warning("No preclusters found")
         pl.DataFrame(schema=EDGES_COLUMNS).write_csv(edges_path, separator="\t")
+        return
+
+    # Remove any existing chunk files so stale data is not merged into output
+    chunk_paths = glob.glob(edges_path + "_*")
+    if chunk_paths:
+        logging.info(f"Removing existing files: {edges_path}_*")
+        for chunk_path in chunk_paths:
+            os.remove(chunk_path)
+
+    if MAX_COASSEMBLY_SAMPLES == 1:
+        sample_list = sorted(list(samples))
+        filtered_targets = (
+            targets
+            .filter(pl.col("coverage") > MIN_COASSEMBLY_COVERAGE)
+            .select(sample = pl.col("sample"), target = pl.col("target"))
+            .unique()
+        )
+
+        sample_preclusters = (
+            sample_preclusters
+            .with_columns(pl.col("samples").str.split(",").cast(pl.List(pl.Categorical)))
+            .select(
+                source_sample = pl.col("samples").list.first(),
+                dest_sample = pl.col("samples").list.get(1, null_on_oob=True)
+                )
+        )
+
+        SINGLE_CHUNK_SIZE = CHUNK_SIZE // 100 + 1
+        num_chunks = (len(sample_list) + SINGLE_CHUNK_SIZE - 1) // SINGLE_CHUNK_SIZE
+
+        logging.info("Processing samples in chunks")
+        with pl.StringCache():
+            for i in range(num_chunks):
+                logging.info(f"Processing cluster {str(i+1)} of {str(num_chunks)}")
+                start_row = i * SINGLE_CHUNK_SIZE
+                chunk_samples = (
+                    pl.DataFrame({"source_sample": sample_list[start_row:start_row + SINGLE_CHUNK_SIZE]})
+                    .with_columns(pl.col("source_sample").cast(pl.Categorical))
+                )
+
+                chunk_targets = (
+                    pl.concat([
+                        sample_preclusters,
+                        sample_preclusters.select(source_sample = "dest_sample", dest_sample = "source_sample")
+                        ])
+                    .join(chunk_samples, on="source_sample")
+                    .lazy()
+                    .join(filtered_targets.select("target", source_sample=pl.col("sample").cast(pl.Categorical)), on="source_sample")
+                    .join(targets.select("target", dest_sample=pl.col("sample").cast(pl.Categorical)), on=["dest_sample", "target"])
+                )
+
+                directional_edges = (
+                    chunk_targets
+                    .group_by("source_sample", "dest_sample")
+                    .agg(target_ids = pl.col("target").cast(pl.Utf8).unique().sort().str.join(","))
+                    .with_columns(
+                        style = pl.lit("directional"),
+                        cluster_size = pl.lit(2),
+                        samples = pl.concat_str(["source_sample", "dest_sample"], separator=","),
+                        )
+                    .select("style", "cluster_size", "samples", "target_ids")
+                )
+
+                singleton_edges = (
+                    filtered_targets
+                    .select("target", source_sample=pl.col("sample").cast(pl.Categorical))
+                    .join(chunk_samples.lazy(), on="source_sample")
+                    .join(chunk_targets, on=["source_sample", "target"], how="anti")
+                    .group_by("source_sample")
+                    .agg(target_ids = pl.col("target").cast(pl.Utf8).unique().sort().str.join(","))
+                    .with_columns(
+                        style = pl.lit("singleton"),
+                        cluster_size = pl.lit(1),
+                        samples = pl.col("source_sample").cast(pl.Utf8),
+                        )
+                    .select("style", "cluster_size", "samples", "target_ids")
+                )
+
+                pl.concat([directional_edges, singleton_edges]).sink_csv(edges_path + f"_{i}", separator="\t")
+
+        (
+            pl.scan_csv(edges_path + "_*", separator="\t", schema_overrides=EDGES_COLUMNS)
+            .sink_csv(edges_path, separator="\t")
+        )
+
+        logging.info("Done")
         return
 
     logging.info("Using chosen clusters to find appropriate targets")
@@ -262,18 +297,10 @@ def streaming_pipeline(
         return(sparse_edges)
 
     num_chunks = (sample_preclusters.height + CHUNK_SIZE - 1) // CHUNK_SIZE # Ceiling division to include all rows
-    # Remove any existing chunk files so stale data is not merged into output
-    chunk_paths = glob.glob(edges_path + "_*")
-    if chunk_paths:
-        logging.info(f"Removing existing files: {edges_path}_*")
-        for chunk_path in chunk_paths:
-            os.remove(chunk_path)
-
     with pl.StringCache():
         logging.info("Processing clusters in chunks")
         for i in range(num_chunks):
-            if True: #i % 100 == 0:
-                logging.info(f"Processing cluster {str(i+1)} of {str(num_chunks)}")
+            logging.info(f"Processing cluster {str(i+1)} of {str(num_chunks)}")
             start_row = i * CHUNK_SIZE
             chunk = sample_preclusters.slice(start_row, CHUNK_SIZE)
             processed_chunk = process_chunk(chunk)
@@ -325,25 +352,19 @@ def pipeline(
         return unbinned.with_columns(pl.col("target").cast(pl.Utf8)), pl.DataFrame(schema=EDGES_COLUMNS)
 
     if MAX_COASSEMBLY_SAMPLES == 1:
-        source = (
+        filtered_targets = (
             unbinned
             .filter(pl.col("coverage") > MIN_COASSEMBLY_COVERAGE)
             .select(
-                source_sample = pl.col("sample"),
+                sample = pl.col("sample"),
                 target = pl.col("target"),
                 )
             .unique()
         )
-        dest = (
-            unbinned
-            .select(
-                dest_sample = pl.col("sample"),
-                target = pl.col("target"),
-                )
-            .unique()
-        )
+        source = filtered_targets.select(pl.col("target"), source_sample = pl.col("sample"))
+        dest = unbinned.select(pl.col("target"), dest_sample = pl.col("sample")).unique()
 
-        sparse_edges = (
+        directional_edges = (
             source
             .join(dest, on="target")
             .filter(pl.col("source_sample") != pl.col("dest_sample"))
@@ -356,6 +377,28 @@ def pipeline(
                 )
             .select("style", "cluster_size", "samples", "target_ids")
         )
+
+        singleton_edges = (
+            filtered_targets
+            .join(
+                dest
+                .group_by("target")
+                .agg(sample_count = pl.n_unique("dest_sample"))
+                .filter(pl.col("sample_count") == 1)
+                .select("target"),
+                on="target",
+            )
+            .group_by("sample")
+            .agg(target_ids = pl.col("target").cast(pl.Utf8).unique().sort().str.join(","))
+            .with_columns(
+                style = pl.lit("singleton"),
+                cluster_size = pl.lit(1),
+                samples = pl.col("sample"),
+                )
+            .select("style", "cluster_size", "samples", "target_ids")
+        )
+
+        sparse_edges = pl.concat([directional_edges, singleton_edges])
 
         return unbinned.with_columns(pl.col("target").cast(pl.Utf8)), sparse_edges
 

--- a/binchicken/workflow/scripts/target_elusive.py
+++ b/binchicken/workflow/scripts/target_elusive.py
@@ -214,7 +214,7 @@ def streaming_pipeline(
                 )
         )
 
-        SINGLE_CHUNK_SIZE = CHUNK_SIZE // 100 + 1
+        SINGLE_CHUNK_SIZE = CHUNK_SIZE // 5 + 1
         num_chunks = (len(sample_list) + SINGLE_CHUNK_SIZE - 1) // SINGLE_CHUNK_SIZE
 
         logging.info("Processing samples in chunks")

--- a/binchicken/workflow/scripts/target_elusive.py
+++ b/binchicken/workflow/scripts/target_elusive.py
@@ -49,10 +49,6 @@ def get_clusters(
     if sample_distances.height == 0:
         return pl.DataFrame(schema={"samples": str})
 
-    if MAX_COASSEMBLY_SAMPLES < 2:
-        # Set to 2 to produce paired edges
-        MAX_COASSEMBLY_SAMPLES = 2
-
     logging.info("Converting to sparse array")
     samples = np.unique(np.concatenate([
         sample_distances.select("query_name").to_numpy().flatten(),
@@ -151,10 +147,6 @@ def streaming_pipeline(
         pl.DataFrame(schema=EDGES_COLUMNS).write_csv(edges_path, separator="\t")
         return
 
-    if MAX_COASSEMBLY_SAMPLES < 2:
-        # Set to 2 to produce paired edges
-        MAX_COASSEMBLY_SAMPLES = 2
-
     # Filter TAXA_OF_INTEREST
     if TAXA_OF_INTEREST:
         logging.info(f"Filtering for taxa of interest: {TAXA_OF_INTEREST}")
@@ -186,6 +178,61 @@ def streaming_pipeline(
     if targets.limit(1).collect().is_empty():
         logging.warning("No SingleM sequences found for the given samples")
         pl.DataFrame(schema=EDGES_COLUMNS).write_csv(edges_path, separator="\t")
+        return
+
+    if MAX_COASSEMBLY_SAMPLES == 1:
+        precluster_keys = []
+        if sample_preclusters.height > 0:
+            precluster_keys = (
+                sample_preclusters
+                .select(pl.col("samples").str.split(",").list.sort().list.join(",").alias("pair_key"))
+                .get_column("pair_key")
+                .to_list()
+            )
+
+        source = (
+            targets
+            .filter(pl.col("coverage") > MIN_COASSEMBLY_COVERAGE)
+            .select(
+                source_sample = pl.col("sample"),
+                target = pl.col("target"),
+                )
+            .unique()
+        )
+        dest = (
+            targets
+            .select(
+                dest_sample = pl.col("sample"),
+                target = pl.col("target"),
+                )
+            .unique()
+        )
+
+        directional_edges = (
+            source
+            .join(dest, on="target")
+            .filter(pl.col("source_sample") != pl.col("dest_sample"))
+        )
+        if precluster_keys:
+            directional_edges = directional_edges.filter(
+                pl.concat_list([pl.col("source_sample"), pl.col("dest_sample")])
+                .list.sort()
+                .list.join(",")
+                .is_in(precluster_keys)
+            )
+
+        (
+            directional_edges
+            .group_by("source_sample", "dest_sample")
+            .agg(target_ids = pl.col("target").cast(pl.Utf8).unique().sort().str.join(","))
+            .with_columns(
+                style = pl.lit("directional"),
+                cluster_size = pl.lit(2),
+                samples = pl.concat_str(["source_sample", "dest_sample"], separator=","),
+                )
+            .select("style", "cluster_size", "samples", "target_ids")
+            .sink_csv(edges_path, separator="\t")
+        )
         return
 
     if sample_preclusters.height == 0:
@@ -254,10 +301,6 @@ def pipeline(
         logging.warning("No unbinned sequences found")
         return unbinned.rename({"found_in": "target"}), pl.DataFrame(schema=EDGES_COLUMNS)
 
-    if MAX_COASSEMBLY_SAMPLES < 2:
-        # Set to 2 to produce paired edges
-        MAX_COASSEMBLY_SAMPLES = 2
-
     # Filter TAXA_OF_INTEREST
     if TAXA_OF_INTEREST:
         logging.info(f"Filtering for taxa of interest: {TAXA_OF_INTEREST}")
@@ -280,6 +323,41 @@ def pipeline(
     if unbinned.height == 0:
         logging.warning("No SingleM sequences found for the given samples")
         return unbinned.with_columns(pl.col("target").cast(pl.Utf8)), pl.DataFrame(schema=EDGES_COLUMNS)
+
+    if MAX_COASSEMBLY_SAMPLES == 1:
+        source = (
+            unbinned
+            .filter(pl.col("coverage") > MIN_COASSEMBLY_COVERAGE)
+            .select(
+                source_sample = pl.col("sample"),
+                target = pl.col("target"),
+                )
+            .unique()
+        )
+        dest = (
+            unbinned
+            .select(
+                dest_sample = pl.col("sample"),
+                target = pl.col("target"),
+                )
+            .unique()
+        )
+
+        sparse_edges = (
+            source
+            .join(dest, on="target")
+            .filter(pl.col("source_sample") != pl.col("dest_sample"))
+            .group_by("source_sample", "dest_sample")
+            .agg(target_ids = pl.col("target").cast(pl.Utf8).unique().sort().str.join(","))
+            .with_columns(
+                style = pl.lit("directional"),
+                cluster_size = pl.lit(2),
+                samples = pl.concat_str(["source_sample", "dest_sample"], separator=","),
+                )
+            .select("style", "cluster_size", "samples", "target_ids")
+        )
+
+        return unbinned.with_columns(pl.col("target").cast(pl.Utf8)), sparse_edges
 
     def process_groups(df):
         if df.height == 1:

--- a/test/data/mock_coassemble/coassemble/pipe_precluster/sample_1_read.otu_table.tsv
+++ b/test/data/mock_coassemble/coassemble/pipe_precluster/sample_1_read.otu_table.tsv
@@ -1,3 +1,3 @@
 gene	sample	sequence	num_hits	coverage	taxonomy
-S3.7.ribosomal_protein_S7	sample_1	ATGACTAGTCATAGCTAGATTTGAGGCAGCAGGAGTTAGGAAAGCCCCCGGAGTTAGCTA	5	10	Root; d__Bacteria; p__Pseudomonadota
-S3.7.ribosomal_protein_S7	sample_1	TGACTAGCTGGGCTAGCTATATTCTTTTTACGAGCGCGAGGAAAGCGACAGCGGCCAGGC	5	10	Root; d__Bacteria; p__Pseudomonadota
+S3.7.ribosomal_protein_S7	sample_1	ATGACTAGTCATAGCTAGATTTGAGGCAGCAGGAGTTAGGAAAGCCCCCGGAGTTAGCTA	5	11	Root; d__Bacteria; p__Pseudomonadota
+S3.7.ribosomal_protein_S7	sample_1	TGACTAGCTGGGCTAGCTATATTCTTTTTACGAGCGCGAGGAAAGCGACAGCGGCCAGGC	5	11	Root; d__Bacteria; p__Pseudomonadota

--- a/test/data/mock_coassemble/coassemble/pipe_precluster/sample_1_read.otu_table.tsv
+++ b/test/data/mock_coassemble/coassemble/pipe_precluster/sample_1_read.otu_table.tsv
@@ -1,3 +1,4 @@
 gene	sample	sequence	num_hits	coverage	taxonomy
 S3.7.ribosomal_protein_S7	sample_1	ATGACTAGTCATAGCTAGATTTGAGGCAGCAGGAGTTAGGAAAGCCCCCGGAGTTAGCTA	5	11	Root; d__Bacteria; p__Pseudomonadota
 S3.7.ribosomal_protein_S7	sample_1	TGACTAGCTGGGCTAGCTATATTCTTTTTACGAGCGCGAGGAAAGCGACAGCGGCCAGGC	5	11	Root; d__Bacteria; p__Pseudomonadota
+S3.7.ribosomal_protein_S7	sample_1	ATGACTAGTCATAGCTAGATTTGAGGTTTACGAGCGCGAGGAAAGCGACAGCGGCCAGGC	5	11	Root; d__Bacteria; p__Pseudomonadota

--- a/test/data/mock_coassemble/coassemble/pipe_precluster/sample_2_read.otu_table.tsv
+++ b/test/data/mock_coassemble/coassemble/pipe_precluster/sample_2_read.otu_table.tsv
@@ -1,3 +1,3 @@
 gene	sample	sequence	num_hits	coverage	taxonomy
-S3.7.ribosomal_protein_S7	sample_2	ATGACTAGTCATAGCTAGATTTGAGGCAGCAGGAGTTAGGAAAGCCCCCGGAGTTAGCTA	5	10	Root; d__Bacteria; p__Abyssobacteria
-S3.7.ribosomal_protein_S7	sample_2	TGACTAGCTGGGCTAGCTATATTCTTTTTACGAGCGCGAGGAAAGCGACAGCGGCCAGGC	5	10	Root; d__Bacteria; p__Abyssobacteria
+S3.7.ribosomal_protein_S7	sample_2	ATGACTAGTCATAGCTAGATTTGAGGCAGCAGGAGTTAGGAAAGCCCCCGGAGTTAGCTA	5	11	Root; d__Bacteria; p__Abyssobacteria
+S3.7.ribosomal_protein_S7	sample_2	TGACTAGCTGGGCTAGCTATATTCTTTTTACGAGCGCGAGGAAAGCGACAGCGGCCAGGC	5	11	Root; d__Bacteria; p__Abyssobacteria

--- a/test/data/mock_coassemble/coassemble/pipe_precluster/sample_3_read.otu_table.tsv
+++ b/test/data/mock_coassemble/coassemble/pipe_precluster/sample_3_read.otu_table.tsv
@@ -1,4 +1,4 @@
 gene	sample	sequence	num_hits	coverage	taxonomy
-S3.7.ribosomal_protein_S7	sample_3	ATCGACTGACTTGATCGATCTTTGACGACGAGAGAGAGAGCGACGCGCCGAGAGGTTTCA	5	10	Root; d__Bacteria; p__Pseudomonadota
-S3.7.ribosomal_protein_S7	sample_3	TACGAGCGGATCGTGCACGTAGTCAGTCGTTATATATCGAAAGCTCATGCGGCCATATCG	5	10	Root; d__Bacteria; p__Pseudomonadota
-S3.7.ribosomal_protein_S7	sample_3	TACGAGCGGATCG---------------GTTATATATCGAAAGCTCATGCGGCCATATCG	5	10	Root; d__Bacteria; p__Pseudomonadota
+S3.7.ribosomal_protein_S7	sample_3	ATCGACTGACTTGATCGATCTTTGACGACGAGAGAGAGAGCGACGCGCCGAGAGGTTTCA	5	11	Root; d__Bacteria; p__Pseudomonadota
+S3.7.ribosomal_protein_S7	sample_3	TACGAGCGGATCGTGCACGTAGTCAGTCGTTATATATCGAAAGCTCATGCGGCCATATCG	5	11	Root; d__Bacteria; p__Pseudomonadota
+S3.7.ribosomal_protein_S7	sample_3	TACGAGCGGATCG---------------GTTATATATCGAAAGCTCATGCGGCCATATCG	5	11	Root; d__Bacteria; p__Pseudomonadota

--- a/test/data/mock_coassemble/coassemble/pipe_precluster/sample_5_read.otu_table.tsv
+++ b/test/data/mock_coassemble/coassemble/pipe_precluster/sample_5_read.otu_table.tsv
@@ -1,4 +1,4 @@
 gene	sample	sequence	num_hits	coverage	taxonomy
-S3.7.ribosomal_protein_S7	sample_5	ATGACTAGTCATAGCTAGATTTGAGGCAGCAGGAGTTAGGAAAGCCCCCGGAGTTAGCTA	5	10	Root; d__Bacteria; p__Abyssobacteria
-S3.7.ribosomal_protein_S7	sample_5	TACGAGCGGATCGTGCACGTAGTCAGTCGTTATATATCGAAAGCTCATGCGGCCATATCG	5	10	Root; d__Bacteria; p__Abyssobacteria
-S3.7.ribosomal_protein_S7	sample_5	TACGAGCGGATCG---------------GTTATATATCGAAAGCTCATGCGGCCATATCG	5	10	Root; d__Bacteria; p__Abyssobacteria
+S3.7.ribosomal_protein_S7	sample_5	ATGACTAGTCATAGCTAGATTTGAGGCAGCAGGAGTTAGGAAAGCCCCCGGAGTTAGCTA	5	11	Root; d__Bacteria; p__Abyssobacteria
+S3.7.ribosomal_protein_S7	sample_5	TACGAGCGGATCGTGCACGTAGTCAGTCGTTATATATCGAAAGCTCATGCGGCCATATCG	5	11	Root; d__Bacteria; p__Abyssobacteria
+S3.7.ribosomal_protein_S7	sample_5	TACGAGCGGATCG---------------GTTATATATCGAAAGCTCATGCGGCCATATCG	5	11	Root; d__Bacteria; p__Abyssobacteria

--- a/test/test_cluster_graph.py
+++ b/test/test_cluster_graph.py
@@ -831,6 +831,36 @@ class Tests(unittest.TestCase):
             )
         self.assertDataFrameEqual(expected, observed)
 
+    def test_cluster_restrict_coassembly_samples_single_assembly_asymmetric(self):
+        elusive_edges = pl.DataFrame([
+            ["directional", 2, "1,2", "1"],
+            ["directional", 2, "2,1", "1,2,3,4"],
+            ["directional", 2, "3,1", "5"],
+            ["directional", 2, "1,3", "5,6"],
+            ["directional", 2, "3,2", "6,7"],
+            ["directional", 2, "2,3", "6,7"],
+        ], orient="row", schema=ELUSIVE_EDGES_COLUMNS)
+        read_size = pl.DataFrame([
+            ["1", 1000],
+            ["2", 1000],
+            ["3", 1000],
+        ], orient="row", schema=READ_SIZE_COLUMNS)
+
+        expected = pl.DataFrame([
+            ["2", 1, 6, 1000, "1,2", "2"],
+            ["1", 1, 3, 1000, "1,3", "1"],
+        ], orient="row", schema=ELUSIVE_CLUSTERS_COLUMNS)
+        observed = pipeline(
+            elusive_edges,
+            read_size,
+            MAX_COASSEMBLY_SAMPLES=1,
+            MIN_COASSEMBLY_SAMPLES=1,
+            MAX_RECOVERY_SAMPLES=2,
+            COASSEMBLY_SAMPLES=["1", "2"],
+            single_assembly=True
+            )
+        self.assertDataFrameEqual(expected, observed, check_row_order=False)
+
     def test_cluster_restrict_coassembly_samples_changed_len(self):
         elusive_edges = pl.DataFrame([
             ["pool", 3, "1,2,3,4,5,6", "1,3"],

--- a/test/test_cluster_graph.py
+++ b/test/test_cluster_graph.py
@@ -118,6 +118,7 @@ class Tests(unittest.TestCase):
             ["directional", 2, "4,3", "3,4"],
             ["directional", 2, "4,5", "5"],
             ["directional", 2, "5,4", "5"],
+            ["singleton", 1, "4", "6"],
         ], orient="row", schema=ELUSIVE_EDGES_COLUMNS)
         read_size = pl.DataFrame([
             ["1", 1000],
@@ -128,7 +129,7 @@ class Tests(unittest.TestCase):
         ], orient="row", schema=READ_SIZE_COLUMNS)
 
         expected = pl.DataFrame([
-            ["4", 1, 5, 4000, "1,2,3,4", "coassembly_0"],
+            ["4", 1, 6, 4000, "1,2,3,4", "coassembly_0"],
             ["1", 1, 4, 1000, "1,2,3,4", "coassembly_1"],
             ["2", 1, 4, 2000, "1,2,3,4", "coassembly_2"],
             ["3", 1, 4, 3000, "1,2,3,4", "coassembly_3"],
@@ -151,6 +152,7 @@ class Tests(unittest.TestCase):
             ["directional", 2, "1,3", "5"],
             ["directional", 2, "3,2", "6,7"],
             ["directional", 2, "2,3", "6,7"],
+            ["singleton", 1, "3", "8"],
         ], orient="row", schema=ELUSIVE_EDGES_COLUMNS)
         read_size = pl.DataFrame([
             ["1", 1000],
@@ -161,7 +163,7 @@ class Tests(unittest.TestCase):
         expected = pl.DataFrame([
             ["2", 1, 6, 1000, "1,2", "coassembly_0"],
             ["1", 1, 5, 1000, "1,2", "coassembly_1"],
-            ["3", 1, 3, 1000, "2,3", "coassembly_2"],
+            ["3", 1, 4, 1000, "2,3", "coassembly_2"],
         ], orient="row", schema=ELUSIVE_CLUSTERS_COLUMNS)
         observed = pipeline(
             elusive_edges,
@@ -199,6 +201,7 @@ class Tests(unittest.TestCase):
         elusive_edges = pl.DataFrame([
             ["directional", 2, "1,2", "1,2,3,4,5,6,7,8,9,10"],
             ["directional", 2, "2,1", "2,3"],
+            ["singleton", 1, "1", "11"],
         ], orient="row", schema=ELUSIVE_EDGES_COLUMNS)
         read_size = pl.DataFrame([
             ["1", 1000],
@@ -206,8 +209,31 @@ class Tests(unittest.TestCase):
         ], orient="row", schema=READ_SIZE_COLUMNS)
 
         expected = pl.DataFrame([
-            ["1", 1, 10, 1000, "1,2", "coassembly_0"],
+            ["1", 1, 11, 1000, "1,2", "coassembly_0"],
             ["2", 1, 2, 2000, "1,2", "coassembly_1"],
+        ], orient="row", schema=ELUSIVE_CLUSTERS_COLUMNS)
+        observed = pipeline(
+            elusive_edges,
+            read_size,
+            MAX_COASSEMBLY_SAMPLES=1,
+            MIN_COASSEMBLY_SAMPLES=1,
+            MAX_RECOVERY_SAMPLES=2,
+            )
+        self.assertDataFrameEqual(expected, observed)
+
+    def test_cluster_single_singleton_only(self):
+        elusive_edges = pl.DataFrame([
+            ["singleton", 1, "1", "1,2"],
+            ["singleton", 1, "2", "3,4"],
+        ], orient="row", schema=ELUSIVE_EDGES_COLUMNS)
+        read_size = pl.DataFrame([
+            ["1", 1000],
+            ["2", 2000],
+        ], orient="row", schema=READ_SIZE_COLUMNS)
+
+        expected = pl.DataFrame([
+            ["1", 1, 2, 1000, "1", "coassembly_0"],
+            ["2", 1, 2, 2000, "2", "coassembly_1"],
         ], orient="row", schema=ELUSIVE_CLUSTERS_COLUMNS)
         observed = pipeline(
             elusive_edges,

--- a/test/test_cluster_graph.py
+++ b/test/test_cluster_graph.py
@@ -836,7 +836,7 @@ class Tests(unittest.TestCase):
             ["directional", 2, "1,2", "1"],
             ["directional", 2, "2,1", "1,2,3,4"],
             ["directional", 2, "3,1", "5"],
-            ["directional", 2, "1,3", "5,6"],
+            ["directional", 2, "1,3", "5,8"],
             ["directional", 2, "3,2", "6,7"],
             ["directional", 2, "2,3", "6,7"],
         ], orient="row", schema=ELUSIVE_EDGES_COLUMNS)

--- a/test/test_cluster_graph.py
+++ b/test/test_cluster_graph.py
@@ -104,13 +104,20 @@ class Tests(unittest.TestCase):
 
     def test_cluster_single_bud(self):
         elusive_edges = pl.DataFrame([
-            ["match", 2, "1,2", "1,2"],
-            ["match", 2, "1,3", "1,3"],
-            ["match", 2, "1,4", "1,4"],
-            ["match", 2, "2,3", "2,3"],
-            ["match", 2, "2,4", "2,4"],
-            ["match", 2, "3,4", "3,4"],
-            ["match", 2, "4,5", "5"],
+            ["directional", 2, "1,2", "1,2"],
+            ["directional", 2, "2,1", "1,2"],
+            ["directional", 2, "1,3", "1,3"],
+            ["directional", 2, "3,1", "1,3"],
+            ["directional", 2, "1,4", "1,4"],
+            ["directional", 2, "4,1", "1,4"],
+            ["directional", 2, "2,3", "2,3"],
+            ["directional", 2, "3,2", "2,3"],
+            ["directional", 2, "2,4", "2,4"],
+            ["directional", 2, "4,2", "2,4"],
+            ["directional", 2, "3,4", "3,4"],
+            ["directional", 2, "4,3", "3,4"],
+            ["directional", 2, "4,5", "5"],
+            ["directional", 2, "5,4", "5"],
         ], orient="row", schema=ELUSIVE_EDGES_COLUMNS)
         read_size = pl.DataFrame([
             ["1", 1000],
@@ -138,9 +145,12 @@ class Tests(unittest.TestCase):
 
     def test_cluster_single_bud_choice(self):
         elusive_edges = pl.DataFrame([
-            ["match", 2, "1,2", "1,2,3,4"],
-            ["match", 2, "3,1", "5"],
-            ["match", 2, "3,2", "6,7"],
+            ["directional", 2, "1,2", "1,2,3,4"],
+            ["directional", 2, "2,1", "1,2,3,4"],
+            ["directional", 2, "3,1", "5"],
+            ["directional", 2, "1,3", "5"],
+            ["directional", 2, "3,2", "6,7"],
+            ["directional", 2, "2,3", "6,7"],
         ], orient="row", schema=ELUSIVE_EDGES_COLUMNS)
         read_size = pl.DataFrame([
             ["1", 1000],
@@ -152,6 +162,52 @@ class Tests(unittest.TestCase):
             ["2", 1, 6, 1000, "1,2", "coassembly_0"],
             ["1", 1, 5, 1000, "1,2", "coassembly_1"],
             ["3", 1, 3, 1000, "2,3", "coassembly_2"],
+        ], orient="row", schema=ELUSIVE_CLUSTERS_COLUMNS)
+        observed = pipeline(
+            elusive_edges,
+            read_size,
+            MAX_COASSEMBLY_SAMPLES=1,
+            MIN_COASSEMBLY_SAMPLES=1,
+            MAX_RECOVERY_SAMPLES=2,
+            )
+        self.assertDataFrameEqual(expected, observed)
+
+    def test_cluster_single_simple(self):
+        elusive_edges = pl.DataFrame([
+            ["directional", 2, "1,2", "1,2"],
+            ["directional", 2, "2,1", "2,3"],
+        ], orient="row", schema=ELUSIVE_EDGES_COLUMNS)
+        read_size = pl.DataFrame([
+            ["1", 1000],
+            ["2", 2000],
+        ], orient="row", schema=READ_SIZE_COLUMNS)
+
+        expected = pl.DataFrame([
+            ["1", 1, 2, 1000, "1,2", "coassembly_0"],
+            ["2", 1, 2, 2000, "1,2", "coassembly_1"],
+        ], orient="row", schema=ELUSIVE_CLUSTERS_COLUMNS)
+        observed = pipeline(
+            elusive_edges,
+            read_size,
+            MAX_COASSEMBLY_SAMPLES=1,
+            MIN_COASSEMBLY_SAMPLES=1,
+            MAX_RECOVERY_SAMPLES=2,
+            )
+        self.assertDataFrameEqual(expected, observed)
+
+    def test_cluster_single_imbalanced(self):
+        elusive_edges = pl.DataFrame([
+            ["directional", 2, "1,2", "1,2,3,4,5,6,7,8,9,10"],
+            ["directional", 2, "2,1", "2,3"],
+        ], orient="row", schema=ELUSIVE_EDGES_COLUMNS)
+        read_size = pl.DataFrame([
+            ["1", 1000],
+            ["2", 2000],
+        ], orient="row", schema=READ_SIZE_COLUMNS)
+
+        expected = pl.DataFrame([
+            ["1", 1, 10, 1000, "1,2", "coassembly_0"],
+            ["2", 1, 2, 2000, "1,2", "coassembly_1"],
         ], orient="row", schema=ELUSIVE_CLUSTERS_COLUMNS)
         observed = pipeline(
             elusive_edges,
@@ -293,12 +349,18 @@ class Tests(unittest.TestCase):
 
     def test_cluster_single_assembly(self):
         elusive_edges = pl.DataFrame([
-            ["match", 2, "1,2", "1"],
-            ["match", 2, "1,3", "1,2"],
-            ["match", 2, "2,3", "1,2,3"],
-            ["match", 2, "4,5", "4,5,6,7"],
-            ["match", 2, "4,6", "4,5,6,7,8"],
-            ["match", 2, "5,6", "4,5,6,7,8,9"],
+            ["directional", 2, "1,2", "1"],
+            ["directional", 2, "2,1", "1"],
+            ["directional", 2, "1,3", "1,2"],
+            ["directional", 2, "3,1", "1,2"],
+            ["directional", 2, "2,3", "1,2,3"],
+            ["directional", 2, "3,2", "1,2,3"],
+            ["directional", 2, "4,5", "4,5,6,7"],
+            ["directional", 2, "5,4", "4,5,6,7"],
+            ["directional", 2, "4,6", "4,5,6,7,8"],
+            ["directional", 2, "6,4", "4,5,6,7,8"],
+            ["directional", 2, "5,6", "4,5,6,7,8,9"],
+            ["directional", 2, "6,5", "4,5,6,7,8,9"],
         ], orient="row", schema=ELUSIVE_EDGES_COLUMNS)
         read_size = pl.DataFrame([
             ["1", 1000],
@@ -715,9 +777,12 @@ class Tests(unittest.TestCase):
 
     def test_cluster_restrict_coassembly_samples_single_assembly(self):
         elusive_edges = pl.DataFrame([
-            ["match", 2, "1,2", "1,2,3,4"],
-            ["match", 2, "3,1", "5"],
-            ["match", 2, "3,2", "6,7"],
+            ["directional", 2, "1,2", "1,2,3,4"],
+            ["directional", 2, "2,1", "1,2,3,4"],
+            ["directional", 2, "3,1", "5"],
+            ["directional", 2, "1,3", "5"],
+            ["directional", 2, "3,2", "6,7"],
+            ["directional", 2, "2,3", "6,7"],
         ], orient="row", schema=ELUSIVE_EDGES_COLUMNS)
         read_size = pl.DataFrame([
             ["1", 1000],
@@ -829,9 +894,12 @@ class Tests(unittest.TestCase):
 
     def test_cluster_anchored_single_bud_choice(self):
         elusive_edges = pl.DataFrame([
-            ["match", 2, "1,2", "1,2,3,4"],
-            ["match", 2, "3,1", "5"],
-            ["match", 2, "3,2", "6,7"],
+            ["directional", 2, "1,2", "1,2,3,4"],
+            ["directional", 2, "2,1", "1,2,3,4"],
+            ["directional", 2, "3,1", "5"],
+            ["directional", 2, "1,3", "5"],
+            ["directional", 2, "3,2", "6,7"],
+            ["directional", 2, "2,3", "6,7"],
         ], orient="row", schema=ELUSIVE_EDGES_COLUMNS)
         read_size = pl.DataFrame([
             ["1", 1000],

--- a/test/test_coassemble.py
+++ b/test/test_coassemble.py
@@ -1744,6 +1744,8 @@ class Tests(unittest.TestCase):
                     ["directional", 2, "sample_5,sample_2", "2099872357664929757"],
                     ["directional", 2, "sample_3,sample_5", "151634836910807220,3420149846979092472"],
                     ["directional", 2, "sample_5,sample_3", "151634836910807220,3420149846979092472"],
+                    ["singleton", 1, "sample_3", "2104372308545519507"],
+                    ["singleton", 1, "sample_1", "3991516532042415735"],
                 ],
                 schema = ["style", "cluster_size", "samples", "target_ids"],
                 orient="row",
@@ -1774,10 +1776,18 @@ class Tests(unittest.TestCase):
                     "\t".join([
                         "sample_3",
                         "1",
-                        "2",
+                        "3",
                         "3624",
                         "sample_3,sample_5",
                         "sample_3"
+                    ]),
+                    "\t".join([
+                        "sample_1",
+                        "1",
+                        "3",
+                        "4832",
+                        "sample_1,sample_2",
+                        "sample_1"
                     ]),
                     "\t".join([
                         "sample_2",
@@ -1786,14 +1796,6 @@ class Tests(unittest.TestCase):
                         "3926",
                         "sample_1,sample_2",
                         "sample_2"
-                    ]),
-                    "\t".join([
-                        "sample_1",
-                        "1",
-                        "2",
-                        "4832",
-                        "sample_1,sample_2",
-                        "sample_1"
                     ]),
                     ""
                 ]

--- a/test/test_coassemble.py
+++ b/test/test_coassemble.py
@@ -861,6 +861,7 @@ class Tests(unittest.TestCase):
                 f"--reverse {SAMPLE_READS_REVERSE} "
                 f"--singlem-metapackage {METAPACKAGE} "
                 f"--single-assembly "
+                f"--min-sequence-coverage 1 "
                 f"--coassembly-samples sample_1 sample_2 "
                 f"--output test "
                 f"--snakemake-args \"cluster_graph\" "
@@ -886,7 +887,7 @@ class Tests(unittest.TestCase):
                     "\t".join([
                         "sample_1",
                         "1",
-                        "4",
+                        "5",
                         "4832",
                         "sample_1,sample_2,sample_3",
                         "sample_1"
@@ -894,7 +895,7 @@ class Tests(unittest.TestCase):
                     "\t".join([
                         "sample_2",
                         "1",
-                        "3",
+                        "4",
                         "3926",
                         "sample_1,sample_2,sample_3",
                         "sample_2"
@@ -1721,6 +1722,7 @@ class Tests(unittest.TestCase):
                 f"--sample-singlem {SAMPLE_SINGLEM_PRE} "
                 f"--single-assembly "
                 f"--singlem-metapackage {METAPACKAGE} "
+                f"--min-sequence-coverage 1 "
                 f"--kmer-precluster always "
                 f"--precluster-size 3 "
                 f"--max-recovery-samples 2 "
@@ -1734,10 +1736,14 @@ class Tests(unittest.TestCase):
             elusive_edges_path = os.path.join("test", "coassemble", "target", "elusive_edges.tsv")
             self.assertTrue(os.path.exists(elusive_edges_path))
             expected = pl.DataFrame([
-                    ["match", 2, "sample_1,sample_2", "1599792511324098285,2099872357664929757"],
-                    ["match", 2, "sample_1,sample_5", "2099872357664929757"],
-                    ["match", 2, "sample_2,sample_5", "2099872357664929757"],
-                    ["match", 2, "sample_3,sample_5", "151634836910807220,3420149846979092472"],
+                    ["directional", 2, "sample_1,sample_2", "1599792511324098285,2099872357664929757"],
+                    ["directional", 2, "sample_2,sample_1", "1599792511324098285,2099872357664929757"],
+                    ["directional", 2, "sample_1,sample_5", "2099872357664929757"],
+                    ["directional", 2, "sample_5,sample_1", "2099872357664929757"],
+                    ["directional", 2, "sample_2,sample_5", "2099872357664929757"],
+                    ["directional", 2, "sample_5,sample_2", "2099872357664929757"],
+                    ["directional", 2, "sample_3,sample_5", "151634836910807220,3420149846979092472"],
+                    ["directional", 2, "sample_5,sample_3", "151634836910807220,3420149846979092472"],
                 ],
                 schema = ["style", "cluster_size", "samples", "target_ids"],
                 orient="row",

--- a/test/test_single.py
+++ b/test/test_single.py
@@ -214,6 +214,8 @@ class Tests(unittest.TestCase):
                     ["directional", 2, "sample_5,sample_2", "2099872357664929757"],
                     ["directional", 2, "sample_3,sample_5", "151634836910807220,3420149846979092472"],
                     ["directional", 2, "sample_5,sample_3", "151634836910807220,3420149846979092472"],
+                    ["singleton", 1, "sample_3", "2104372308545519507"],
+                    ["singleton", 1, "sample_1", "3991516532042415735"],
                 ],
                 schema = ["style", "cluster_size", "samples", "target_ids"],
                 orient="row",
@@ -244,10 +246,18 @@ class Tests(unittest.TestCase):
                     "\t".join([
                         "sample_3",
                         "1",
-                        "2",
+                        "3",
                         "3624",
                         "sample_3,sample_5",
                         "sample_3"
+                    ]),
+                    "\t".join([
+                        "sample_1",
+                        "1",
+                        "3",
+                        "4832",
+                        "sample_1,sample_2",
+                        "sample_1"
                     ]),
                     "\t".join([
                         "sample_2",
@@ -256,14 +266,6 @@ class Tests(unittest.TestCase):
                         "3926",
                         "sample_1,sample_2",
                         "sample_2"
-                    ]),
-                    "\t".join([
-                        "sample_1",
-                        "1",
-                        "2",
-                        "4832",
-                        "sample_1,sample_2",
-                        "sample_1"
                     ]),
                     ""
                 ]
@@ -312,6 +314,8 @@ class Tests(unittest.TestCase):
                     ["directional", 2, "sample_5,sample_2", "2099872357664929757"],
                     ["directional", 2, "sample_3,sample_5", "151634836910807220,3420149846979092472"],
                     ["directional", 2, "sample_5,sample_3", "151634836910807220,3420149846979092472"],
+                    ["singleton", 1, "sample_3", "2104372308545519507"],
+                    ["singleton", 1, "sample_1", "3991516532042415735"],
                 ],
                 schema = ["style", "cluster_size", "samples", "target_ids"],
                 orient="row",
@@ -342,10 +346,18 @@ class Tests(unittest.TestCase):
                     "\t".join([
                         "sample_3",
                         "1",
-                        "2",
+                        "3",
                         "3624",
                         "sample_3,sample_5",
                         "sample_3"
+                    ]),
+                    "\t".join([
+                        "sample_1",
+                        "1",
+                        "3",
+                        "4832",
+                        "sample_1,sample_2",
+                        "sample_1"
                     ]),
                     "\t".join([
                         "sample_2",
@@ -354,14 +366,6 @@ class Tests(unittest.TestCase):
                         "3926",
                         "sample_1,sample_2",
                         "sample_2"
-                    ]),
-                    "\t".join([
-                        "sample_1",
-                        "1",
-                        "2",
-                        "4832",
-                        "sample_1,sample_2",
-                        "sample_1"
                     ]),
                     ""
                 ]

--- a/test/test_single.py
+++ b/test/test_single.py
@@ -46,6 +46,7 @@ class Tests(unittest.TestCase):
                 f"--forward {SAMPLE_READS_FORWARD} "
                 f"--reverse {SAMPLE_READS_REVERSE} "
                 f"--singlem-metapackage {METAPACKAGE} "
+                f"--min-sequence-coverage 1 "
                 f"--coassembly-samples sample_1 sample_2 "
                 f"--output test "
             )
@@ -69,7 +70,7 @@ class Tests(unittest.TestCase):
                     "\t".join([
                         "sample_1",
                         "1",
-                        "4",
+                        "5",
                         "4832",
                         "sample_1,sample_2,sample_3",
                         "sample_1"
@@ -77,7 +78,7 @@ class Tests(unittest.TestCase):
                     "\t".join([
                         "sample_2",
                         "1",
-                        "3",
+                        "4",
                         "3926",
                         "sample_1,sample_2,sample_3",
                         "sample_2"
@@ -168,14 +169,14 @@ class Tests(unittest.TestCase):
                         "sample_1",
                         "sample_1",
                         "1",
-                        "4",
+                        "5",
                         "4832",
                     ]),
                     "\t".join([
                         "sample_2",
                         "sample_2",
                         "1",
-                        "3",
+                        "4",
                         "3926",
                     ]),
                     ""
@@ -205,10 +206,14 @@ class Tests(unittest.TestCase):
             elusive_edges_path = os.path.join("test", "coassemble", "target", "elusive_edges.tsv")
             self.assertTrue(os.path.exists(elusive_edges_path))
             expected = pl.DataFrame([
-                    ["match", 2, "sample_1,sample_2", "1599792511324098285,2099872357664929757"],
-                    ["match", 2, "sample_1,sample_5", "2099872357664929757"],
-                    ["match", 2, "sample_2,sample_5", "2099872357664929757"],
-                    ["match", 2, "sample_3,sample_5", "151634836910807220,3420149846979092472"],
+                    ["directional", 2, "sample_1,sample_2", "1599792511324098285,2099872357664929757"],
+                    ["directional", 2, "sample_2,sample_1", "1599792511324098285,2099872357664929757"],
+                    ["directional", 2, "sample_1,sample_5", "2099872357664929757"],
+                    ["directional", 2, "sample_5,sample_1", "2099872357664929757"],
+                    ["directional", 2, "sample_2,sample_5", "2099872357664929757"],
+                    ["directional", 2, "sample_5,sample_2", "2099872357664929757"],
+                    ["directional", 2, "sample_3,sample_5", "151634836910807220,3420149846979092472"],
+                    ["directional", 2, "sample_5,sample_3", "151634836910807220,3420149846979092472"],
                 ],
                 schema = ["style", "cluster_size", "samples", "target_ids"],
                 orient="row",
@@ -299,10 +304,14 @@ class Tests(unittest.TestCase):
             elusive_edges_path = os.path.join("test", "coassemble", "target", "elusive_edges.tsv")
             self.assertTrue(os.path.exists(elusive_edges_path))
             expected = pl.DataFrame([
-                    ["match", 2, "sample_1,sample_2", "1599792511324098285,2099872357664929757"],
-                    ["match", 2, "sample_1,sample_5", "2099872357664929757"],
-                    ["match", 2, "sample_2,sample_5", "2099872357664929757"],
-                    ["match", 2, "sample_3,sample_5", "151634836910807220,3420149846979092472"],
+                    ["directional", 2, "sample_1,sample_2", "1599792511324098285,2099872357664929757"],
+                    ["directional", 2, "sample_2,sample_1", "1599792511324098285,2099872357664929757"],
+                    ["directional", 2, "sample_1,sample_5", "2099872357664929757"],
+                    ["directional", 2, "sample_5,sample_1", "2099872357664929757"],
+                    ["directional", 2, "sample_2,sample_5", "2099872357664929757"],
+                    ["directional", 2, "sample_5,sample_2", "2099872357664929757"],
+                    ["directional", 2, "sample_3,sample_5", "151634836910807220,3420149846979092472"],
+                    ["directional", 2, "sample_5,sample_3", "151634836910807220,3420149846979092472"],
                 ],
                 schema = ["style", "cluster_size", "samples", "target_ids"],
                 orient="row",

--- a/test/test_target_elusive.py
+++ b/test/test_target_elusive.py
@@ -1180,6 +1180,38 @@ class Tests(unittest.TestCase):
             self.assertDataFrameEqual(expected_targets, observed_targets)
             self.assertDataFrameEqual(expected_edges, observed_edges)
 
+    def test_streaming_pipeline_clears_stale_edge_chunks(self):
+        with in_tempdir():
+            unbinned = pl.LazyFrame([
+                ["S3.1", "sample_1", "AAA", 1, 12, "Root", ""],
+                ["S3.1", "sample_1", "AAB", 1, 5, "Root", ""],
+            ], orient="row", schema=APPRAISE_COLUMNS)
+            samples = set(["sample_1"])
+            preclusters = pl.DataFrame([
+                ["sample_1"],
+            ], orient="row", schema=CLUSTERS_COLUMNS)
+
+            stale_edges = pl.DataFrame([
+                ["match", 1, "sample_1", "999"],
+            ], orient="row", schema=EDGES_COLUMNS)
+            stale_edges.write_csv("edges.tsv_5", separator="\t")
+
+            expected_edges = pl.DataFrame([
+                ["match", 1, "sample_1", "5724869768496956987"],
+            ], orient="row", schema=EDGES_COLUMNS)
+
+            streaming_pipeline(
+                unbinned,
+                samples,
+                sample_preclusters=preclusters,
+                targets_path="targets.tsv",
+                edges_path="edges.tsv",
+                MIN_COASSEMBLY_COVERAGE=10,
+                CHUNK_SIZE=100,
+                )
+            observed_edges = pl.read_csv("edges.tsv", schema_overrides=EDGES_COLUMNS, separator="\t")
+            self.assertDataFrameEqual(expected_edges, observed_edges)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_target_elusive.py
+++ b/test/test_target_elusive.py
@@ -901,27 +901,62 @@ class Tests(unittest.TestCase):
 
     def test_target_elusive_single_assembly(self):
         unbinned = pl.DataFrame([
-            ["S3.1", "sample_1", "AAA", 5, 10, "Root", ""],
-            ["S3.1", "sample_1", "AAB", 5, 10, "Root", ""],
-            ["S3.1", "sample_2", "AAA", 5, 10, "Root", ""],
-            ["S3.1", "sample_2", "AAB", 5, 10, "Root", ""],
-            ["S3.1", "sample_3", "AAA", 5, 10, "Root", ""],
-            ["S3.1", "sample_3", "AAC", 5, 10, "Root", ""],
+            ["S3.1", "sample_1", "AAA", 5, 11, "Root", ""],
+            ["S3.1", "sample_1", "AAB", 5, 11, "Root", ""],
+            ["S3.1", "sample_2", "AAA", 5, 11, "Root", ""],
+            ["S3.1", "sample_2", "AAB", 5, 11, "Root", ""],
+            ["S3.1", "sample_3", "AAA", 5, 11, "Root", ""],
+            ["S3.1", "sample_3", "AAC", 5, 11, "Root", ""],
         ], orient="row", schema=APPRAISE_COLUMNS)
         samples = set(["sample_1", "sample_2", "sample_3"])
 
         expected_targets = pl.DataFrame([
-            ["S3.1", "sample_1", "AAA", 5, 10, "Root", "0"],
-            ["S3.1", "sample_1", "AAB", 5, 10, "Root", "1"],
-            ["S3.1", "sample_2", "AAA", 5, 10, "Root", "0"],
-            ["S3.1", "sample_2", "AAB", 5, 10, "Root", "1"],
-            ["S3.1", "sample_3", "AAA", 5, 10, "Root", "0"],
-            ["S3.1", "sample_3", "AAC", 5, 10, "Root", "2"],
+            ["S3.1", "sample_1", "AAA", 5, 11, "Root", "0"],
+            ["S3.1", "sample_1", "AAB", 5, 11, "Root", "1"],
+            ["S3.1", "sample_2", "AAA", 5, 11, "Root", "0"],
+            ["S3.1", "sample_2", "AAB", 5, 11, "Root", "1"],
+            ["S3.1", "sample_3", "AAA", 5, 11, "Root", "0"],
+            ["S3.1", "sample_3", "AAC", 5, 11, "Root", "2"],
         ], orient="row", schema=TARGETS_COLUMNS)
         expected_edges = pl.DataFrame([
-            ["match", 2, "sample_1,sample_2", "0,1"],
-            ["match", 2, "sample_1,sample_3", "0"],
-            ["match", 2, "sample_2,sample_3", "0"],
+            ["directional", 2, "sample_1,sample_2", "0,1"],
+            ["directional", 2, "sample_2,sample_1", "0,1"],
+            ["directional", 2, "sample_1,sample_3", "0"],
+            ["directional", 2, "sample_3,sample_1", "0"],
+            ["directional", 2, "sample_2,sample_3", "0"],
+            ["directional", 2, "sample_3,sample_2", "0"],
+        ], orient="row", schema=EDGES_COLUMNS)
+
+        observed_targets, observed_edges = pipeline(unbinned, samples, MAX_COASSEMBLY_SAMPLES=1)
+        self.assertDataFrameEqual(expected_targets, observed_targets)
+        self.assertDataFrameEqual(expected_edges, observed_edges)
+
+    def test_target_elusive_single_assembly_imbalanced(self):
+        unbinned = pl.DataFrame([
+            ["S3.1", "sample_1", "AAA", 5, 11, "Root", ""],
+            ["S3.1", "sample_1", "AAB", 5, 11, "Root", ""],
+            ["S3.1", "sample_2", "AAA", 4, 8, "Root", ""],
+            ["S3.1", "sample_2", "AAB", 4, 8, "Root", ""],
+            ["S3.1", "sample_3", "AAA", 5, 11, "Root", ""],
+            ["S3.1", "sample_3", "AAC", 5, 11, "Root", ""],
+        ], orient="row", schema=APPRAISE_COLUMNS)
+        samples = set(["sample_1", "sample_2", "sample_3"])
+
+        expected_targets = pl.DataFrame([
+            ["S3.1", "sample_1", "AAA", 5, 11, "Root", "0"],
+            ["S3.1", "sample_1", "AAB", 5, 11, "Root", "1"],
+            ["S3.1", "sample_2", "AAA", 4, 8, "Root", "0"],
+            ["S3.1", "sample_2", "AAB", 4, 8, "Root", "1"],
+            ["S3.1", "sample_3", "AAA", 5, 11, "Root", "0"],
+            ["S3.1", "sample_3", "AAC", 5, 11, "Root", "2"],
+        ], orient="row", schema=TARGETS_COLUMNS)
+        expected_edges = pl.DataFrame([
+            ["directional", 2, "sample_1,sample_2", "0,1"],
+            # ["directional", 2, "sample_2,sample_1", "0,1"],
+            ["directional", 2, "sample_1,sample_3", "0"],
+            ["directional", 2, "sample_3,sample_1", "0"],
+            # ["directional", 2, "sample_2,sample_3", "0"],
+            ["directional", 2, "sample_3,sample_2", "0"],
         ], orient="row", schema=EDGES_COLUMNS)
 
         observed_targets, observed_edges = pipeline(unbinned, samples, MAX_COASSEMBLY_SAMPLES=1)
@@ -984,12 +1019,12 @@ class Tests(unittest.TestCase):
     def test_target_elusive_preclustered_single_assembly(self):
         with in_tempdir():
             unbinned = pl.LazyFrame([
-                ["S3.1", "sample_1", "AAA", 5, 10, "Root", ""],
-                ["S3.1", "sample_1", "AAB", 5, 10, "Root", ""],
-                ["S3.1", "sample_2", "AAA", 5, 10, "Root", ""],
-                ["S3.1", "sample_2", "AAB", 5, 10, "Root", ""],
-                ["S3.1", "sample_3", "AAA", 5, 10, "Root", ""],
-                ["S3.1", "sample_3", "AAC", 5, 10, "Root", ""],
+                ["S3.1", "sample_1", "AAA", 5, 11, "Root", ""],
+                ["S3.1", "sample_1", "AAB", 5, 11, "Root", ""],
+                ["S3.1", "sample_2", "AAA", 5, 11, "Root", ""],
+                ["S3.1", "sample_2", "AAB", 5, 11, "Root", ""],
+                ["S3.1", "sample_3", "AAA", 5, 11, "Root", ""],
+                ["S3.1", "sample_3", "AAC", 5, 11, "Root", ""],
             ], orient="row", schema=APPRAISE_COLUMNS)
             samples = set(["sample_1", "sample_2", "sample_3"])
             preclusters = pl.DataFrame([
@@ -999,17 +1034,68 @@ class Tests(unittest.TestCase):
             ], orient="row", schema=CLUSTERS_COLUMNS)
 
             expected_targets = pl.DataFrame([
-                ["S3.1", "sample_1", "AAA", 5, 10, "Root", "5724869768496956987"],
-                ["S3.1", "sample_1", "AAB", 5, 10, "Root", "6753533720934362372"],
-                ["S3.1", "sample_2", "AAA", 5, 10, "Root", "5724869768496956987"],
-                ["S3.1", "sample_2", "AAB", 5, 10, "Root", "6753533720934362372"],
-                ["S3.1", "sample_3", "AAA", 5, 10, "Root", "5724869768496956987"],
-                ["S3.1", "sample_3", "AAC", 5, 10, "Root", "6071535188791011068"],
+                ["S3.1", "sample_1", "AAA", 5, 11, "Root", "5724869768496956987"],
+                ["S3.1", "sample_1", "AAB", 5, 11, "Root", "6753533720934362372"],
+                ["S3.1", "sample_2", "AAA", 5, 11, "Root", "5724869768496956987"],
+                ["S3.1", "sample_2", "AAB", 5, 11, "Root", "6753533720934362372"],
+                ["S3.1", "sample_3", "AAA", 5, 11, "Root", "5724869768496956987"],
+                ["S3.1", "sample_3", "AAC", 5, 11, "Root", "6071535188791011068"],
             ], orient="row", schema=TARGETS_COLUMNS)
             expected_edges = pl.DataFrame([
-                # ["match", 2, "sample_1,sample_2", "5724869768496956987,6753533720934362372"],
-                ["match", 2, "sample_1,sample_3", "5724869768496956987"],
-                ["match", 2, "sample_2,sample_3", "5724869768496956987"],
+                # ["directional", 2, "sample_1,sample_2", "5724869768496956987,6753533720934362372"],
+                # ["directional", 2, "sample_2,sample_1", "5724869768496956987,6753533720934362372"],
+                ["directional", 2, "sample_1,sample_3", "5724869768496956987"],
+                ["directional", 2, "sample_3,sample_1", "5724869768496956987"],
+                ["directional", 2, "sample_2,sample_3", "5724869768496956987"],
+                ["directional", 2, "sample_3,sample_2", "5724869768496956987"],
+            ], orient="row", schema=EDGES_COLUMNS)
+
+            streaming_pipeline(
+                unbinned,
+                samples,
+                sample_preclusters=preclusters,
+                targets_path="targets.tsv",
+                edges_path="edges.tsv",
+                MAX_COASSEMBLY_SAMPLES=1,
+                CHUNK_SIZE=2,
+                )
+            observed_targets = pl.read_csv("targets.tsv", schema_overrides=TARGETS_COLUMNS, separator="\t")
+            observed_edges = pl.read_csv("edges.tsv", schema_overrides=EDGES_COLUMNS, separator="\t")
+            self.assertDataFrameEqual(expected_targets, observed_targets)
+            self.assertDataFrameEqual(expected_edges, observed_edges)
+
+    def test_target_elusive_preclustered_single_assembly_imbalanced(self):
+        with in_tempdir():
+            unbinned = pl.LazyFrame([
+                ["S3.1", "sample_1", "AAA", 5, 11, "Root", ""],
+                ["S3.1", "sample_1", "AAB", 5, 11, "Root", ""],
+                ["S3.1", "sample_2", "AAA", 4, 8, "Root", ""],
+                ["S3.1", "sample_2", "AAB", 4, 8, "Root", ""],
+                ["S3.1", "sample_3", "AAA", 5, 11, "Root", ""],
+                ["S3.1", "sample_3", "AAC", 5, 11, "Root", ""],
+            ], orient="row", schema=APPRAISE_COLUMNS)
+            samples = set(["sample_1", "sample_2", "sample_3"])
+            preclusters = pl.DataFrame([
+                # ["sample_1,sample_2"],
+                ["sample_1,sample_3"],
+                ["sample_2,sample_3"],
+            ], orient="row", schema=CLUSTERS_COLUMNS)
+
+            expected_targets = pl.DataFrame([
+                ["S3.1", "sample_1", "AAA", 5, 11, "Root", "5724869768496956987"],
+                ["S3.1", "sample_1", "AAB", 5, 11, "Root", "6753533720934362372"],
+                ["S3.1", "sample_2", "AAA", 4, 8, "Root", "5724869768496956987"],
+                ["S3.1", "sample_2", "AAB", 4, 8, "Root", "6753533720934362372"],
+                ["S3.1", "sample_3", "AAA", 5, 11, "Root", "5724869768496956987"],
+                ["S3.1", "sample_3", "AAC", 5, 11, "Root", "6071535188791011068"],
+            ], orient="row", schema=TARGETS_COLUMNS)
+            expected_edges = pl.DataFrame([
+                # ["directional", 2, "sample_1,sample_2", "5724869768496956987,6753533720934362372"],
+                # ["directional", 2, "sample_2,sample_1", "5724869768496956987,6753533720934362372"],
+                ["directional", 2, "sample_1,sample_3", "5724869768496956987"],
+                ["directional", 2, "sample_3,sample_1", "5724869768496956987"],
+                # ["directional", 2, "sample_2,sample_3", "5724869768496956987"],
+                ["directional", 2, "sample_3,sample_2", "5724869768496956987"],
             ], orient="row", schema=EDGES_COLUMNS)
 
             streaming_pipeline(
@@ -1029,12 +1115,12 @@ class Tests(unittest.TestCase):
     def test_target_elusive_preclustered_coalesce_target(self):
         with in_tempdir():
             unbinned = pl.LazyFrame([
-                ["S3.1", "sample_1", "AAA", 5, 10, "Root", ""],
-                ["S3.1", "sample_1", "AAB", 5, 10, "Root", ""],
-                ["S3.1", "sample_2", "AAA", 5, 10, "Root", ""],
-                ["S3.1", "sample_2", "AAB", 5, 10, "Root", ""],
-                ["S3.1", "sample_3", "AAA", 5, 10, "Root", ""],
-                ["S3.1", "sample_3", "AAC", 5, 10, "Root", ""],
+                ["S3.1", "sample_1", "AAA", 5, 11, "Root", ""],
+                ["S3.1", "sample_1", "AAB", 5, 11, "Root", ""],
+                ["S3.1", "sample_2", "AAA", 5, 11, "Root", ""],
+                ["S3.1", "sample_2", "AAB", 5, 11, "Root", ""],
+                ["S3.1", "sample_3", "AAA", 5, 11, "Root", ""],
+                ["S3.1", "sample_3", "AAC", 5, 11, "Root", ""],
             ], orient="row", schema=APPRAISE_COLUMNS)
             samples = set(["sample_1", "sample_2", "sample_3"])
             preclusters = pl.DataFrame([
@@ -1044,17 +1130,68 @@ class Tests(unittest.TestCase):
             ], orient="row", schema=CLUSTERS_COLUMNS)
 
             expected_targets = pl.DataFrame([
-                ["S3.1", "sample_1", "AAA", 5, 10, "Root", "5724869768496956987"],
-                ["S3.1", "sample_1", "AAB", 5, 10, "Root", "6753533720934362372"],
-                ["S3.1", "sample_2", "AAA", 5, 10, "Root", "5724869768496956987"],
-                ["S3.1", "sample_2", "AAB", 5, 10, "Root", "6753533720934362372"],
-                ["S3.1", "sample_3", "AAA", 5, 10, "Root", "5724869768496956987"],
-                ["S3.1", "sample_3", "AAC", 5, 10, "Root", "6071535188791011068"],
+                ["S3.1", "sample_1", "AAA", 5, 11, "Root", "5724869768496956987"],
+                ["S3.1", "sample_1", "AAB", 5, 11, "Root", "6753533720934362372"],
+                ["S3.1", "sample_2", "AAA", 5, 11, "Root", "5724869768496956987"],
+                ["S3.1", "sample_2", "AAB", 5, 11, "Root", "6753533720934362372"],
+                ["S3.1", "sample_3", "AAA", 5, 11, "Root", "5724869768496956987"],
+                ["S3.1", "sample_3", "AAC", 5, 11, "Root", "6071535188791011068"],
             ], orient="row", schema=TARGETS_COLUMNS)
             expected_edges = pl.DataFrame([
-                ["match", 2, "sample_1,sample_2", "5724869768496956987,6753533720934362372"],
-                ["match", 2, "sample_1,sample_3", "5724869768496956987"],
-                ["match", 2, "sample_2,sample_3", "5724869768496956987"],
+                ["directional", 2, "sample_1,sample_2", "5724869768496956987,6753533720934362372"],
+                ["directional", 2, "sample_2,sample_1", "5724869768496956987,6753533720934362372"],
+                ["directional", 2, "sample_1,sample_3", "5724869768496956987"],
+                ["directional", 2, "sample_3,sample_1", "5724869768496956987"],
+                ["directional", 2, "sample_2,sample_3", "5724869768496956987"],
+                ["directional", 2, "sample_3,sample_2", "5724869768496956987"],
+            ], orient="row", schema=EDGES_COLUMNS)
+
+            streaming_pipeline(
+                unbinned,
+                samples,
+                sample_preclusters=preclusters,
+                targets_path="targets.tsv",
+                edges_path="edges.tsv",
+                MAX_COASSEMBLY_SAMPLES=1,
+                CHUNK_SIZE=2,
+                )
+            observed_targets = pl.read_csv("targets.tsv", schema_overrides=TARGETS_COLUMNS, separator="\t")
+            observed_edges = pl.read_csv("edges.tsv", schema_overrides=EDGES_COLUMNS, separator="\t")
+            self.assertDataFrameEqual(expected_targets, observed_targets)
+            self.assertDataFrameEqual(expected_edges, observed_edges)
+
+    def test_target_elusive_preclustered_coalesce_target_imbalanced(self):
+        with in_tempdir():
+            unbinned = pl.LazyFrame([
+                ["S3.1", "sample_1", "AAA", 5, 11, "Root", ""],
+                ["S3.1", "sample_1", "AAB", 5, 11, "Root", ""],
+                ["S3.1", "sample_2", "AAA", 4, 8, "Root", ""],
+                ["S3.1", "sample_2", "AAB", 4, 8, "Root", ""],
+                ["S3.1", "sample_3", "AAA", 5, 11, "Root", ""],
+                ["S3.1", "sample_3", "AAC", 5, 11, "Root", ""],
+            ], orient="row", schema=APPRAISE_COLUMNS)
+            samples = set(["sample_1", "sample_2", "sample_3"])
+            preclusters = pl.DataFrame([
+                ["sample_1,sample_2"],
+                ["sample_1,sample_3"],
+                ["sample_2,sample_3"],
+            ], orient="row", schema=CLUSTERS_COLUMNS)
+
+            expected_targets = pl.DataFrame([
+                ["S3.1", "sample_1", "AAA", 5, 11, "Root", "5724869768496956987"],
+                ["S3.1", "sample_1", "AAB", 5, 11, "Root", "6753533720934362372"],
+                ["S3.1", "sample_2", "AAA", 4, 8, "Root", "5724869768496956987"],
+                ["S3.1", "sample_2", "AAB", 4, 8, "Root", "6753533720934362372"],
+                ["S3.1", "sample_3", "AAA", 5, 11, "Root", "5724869768496956987"],
+                ["S3.1", "sample_3", "AAC", 5, 11, "Root", "6071535188791011068"],
+            ], orient="row", schema=TARGETS_COLUMNS)
+            expected_edges = pl.DataFrame([
+                ["directional", 2, "sample_1,sample_2", "5724869768496956987,6753533720934362372"],
+                # ["directional", 2, "sample_2,sample_1", "5724869768496956987,6753533720934362372"],
+                ["directional", 2, "sample_1,sample_3", "5724869768496956987"],
+                ["directional", 2, "sample_3,sample_1", "5724869768496956987"],
+                # ["directional", 2, "sample_2,sample_3", "5724869768496956987"],
+                ["directional", 2, "sample_3,sample_2", "5724869768496956987"],
             ], orient="row", schema=EDGES_COLUMNS)
 
             streaming_pipeline(

--- a/test/test_target_elusive.py
+++ b/test/test_target_elusive.py
@@ -925,6 +925,7 @@ class Tests(unittest.TestCase):
             ["directional", 2, "sample_3,sample_1", "0"],
             ["directional", 2, "sample_2,sample_3", "0"],
             ["directional", 2, "sample_3,sample_2", "0"],
+            ["singleton", 1, "sample_3", "2"],
         ], orient="row", schema=EDGES_COLUMNS)
 
         observed_targets, observed_edges = pipeline(unbinned, samples, MAX_COASSEMBLY_SAMPLES=1)
@@ -957,6 +958,7 @@ class Tests(unittest.TestCase):
             ["directional", 2, "sample_3,sample_1", "0"],
             # ["directional", 2, "sample_2,sample_3", "0"],
             ["directional", 2, "sample_3,sample_2", "0"],
+            ["singleton", 1, "sample_3", "2"],
         ], orient="row", schema=EDGES_COLUMNS)
 
         observed_targets, observed_edges = pipeline(unbinned, samples, MAX_COASSEMBLY_SAMPLES=1)
@@ -1044,10 +1046,13 @@ class Tests(unittest.TestCase):
             expected_edges = pl.DataFrame([
                 # ["directional", 2, "sample_1,sample_2", "5724869768496956987,6753533720934362372"],
                 # ["directional", 2, "sample_2,sample_1", "5724869768496956987,6753533720934362372"],
+                ["singleton", 1, "sample_1", "6753533720934362372"],
+                ["singleton", 1, "sample_2", "6753533720934362372"],
                 ["directional", 2, "sample_1,sample_3", "5724869768496956987"],
                 ["directional", 2, "sample_3,sample_1", "5724869768496956987"],
                 ["directional", 2, "sample_2,sample_3", "5724869768496956987"],
                 ["directional", 2, "sample_3,sample_2", "5724869768496956987"],
+                ["singleton", 1, "sample_3", "6071535188791011068"],
             ], orient="row", schema=EDGES_COLUMNS)
 
             streaming_pipeline(
@@ -1092,10 +1097,12 @@ class Tests(unittest.TestCase):
             expected_edges = pl.DataFrame([
                 # ["directional", 2, "sample_1,sample_2", "5724869768496956987,6753533720934362372"],
                 # ["directional", 2, "sample_2,sample_1", "5724869768496956987,6753533720934362372"],
+                ["singleton", 1, "sample_1", "6753533720934362372"],
                 ["directional", 2, "sample_1,sample_3", "5724869768496956987"],
                 ["directional", 2, "sample_3,sample_1", "5724869768496956987"],
                 # ["directional", 2, "sample_2,sample_3", "5724869768496956987"],
                 ["directional", 2, "sample_3,sample_2", "5724869768496956987"],
+                ["singleton", 1, "sample_3", "6071535188791011068"],
             ], orient="row", schema=EDGES_COLUMNS)
 
             streaming_pipeline(
@@ -1144,6 +1151,7 @@ class Tests(unittest.TestCase):
                 ["directional", 2, "sample_3,sample_1", "5724869768496956987"],
                 ["directional", 2, "sample_2,sample_3", "5724869768496956987"],
                 ["directional", 2, "sample_3,sample_2", "5724869768496956987"],
+                ["singleton", 1, "sample_3", "6071535188791011068"],
             ], orient="row", schema=EDGES_COLUMNS)
 
             streaming_pipeline(
@@ -1192,6 +1200,7 @@ class Tests(unittest.TestCase):
                 ["directional", 2, "sample_3,sample_1", "5724869768496956987"],
                 # ["directional", 2, "sample_2,sample_3", "5724869768496956987"],
                 ["directional", 2, "sample_3,sample_2", "5724869768496956987"],
+                ["singleton", 1, "sample_3", "6071535188791011068"],
             ], orient="row", schema=EDGES_COLUMNS)
 
             streaming_pipeline(


### PR DESCRIPTION
Single-sample target counts included targets that were <=10X coverage in the specific sample, as long as the target had >10X summed coverage when paired when at least one other sample.
This greatly inflates the predicted target recovery.